### PR TITLE
Fix order of parameter in getStateForAction

### DIFF
--- a/docs/custom-routers.md
+++ b/docs/custom-routers.md
@@ -27,7 +27,7 @@ class MyNavigator extends React.Component {
 ![Routers manage the relationship between URIs, actions, and navigation state](./assets/routers/routers-concept-map.png)
 
 
-### `getStateForAction(action, state)`
+### `getStateForAction(state, action)`
 
 Defines the navigation state in response to a given action. This function will be run when an action gets passed into `props.navigation.dispatch(`, or when any of the helper functions are called, like `navigation.navigate(`.
 


### PR DESCRIPTION
Simple typo.

StackRouter source code [here](https://github.com/react-navigation/react-navigation/blob/fae1f71fb3f3fcbf7ad8ffdb9e0f5f1a840bf660/src/routers/StackRouter.js#L101).