### PR TITLE
document react-navigation-header-buttons

### DIFF
--- a/docs/header-buttons.md
+++ b/docs/header-buttons.md
@@ -29,6 +29,8 @@ class HomeScreen extends React.Component {
 
 The binding of `this` in `navigationOptions` is _not_ the `HomeScreen` instance, so you can't call `setState` or any instance methods on it. This is pretty important because it's extremely common to want the buttons in your header to interact with the screen that the header belongs to. So, we will look how to do this next.
 
+There is a community-developed package for rendering buttons in the header with the correct styling available [react-navigation-header-buttons](https://github.com/vonovak/react-navigation-header-buttons).
+
 ## Header interaction with its screen component
 
 The most commonly used pattern for giving a header button access to a function on the component instance is to use `params`. We'll demonstrate this with a classic example, the counter.


### PR DESCRIPTION
So I wrote this package for rendering header buttons that should make people's life easier: https://github.com/vonovak/react-navigation-header-buttons (demo: https://expo.io/@vonovak/navbar-buttons-demo).

This place in the docs is ideal for it to appear, but I'm not sure if it's a good idea to link to some random guy's git repo in the middle of the page (it doesn't seem to be a good precedent to me).

I was thinking we may create a new page with community contributions and collect such packages there? (I have one more that I'd like to share since it may be useful: https://github.com/vonovak/react-navigation-props-mapper).
Alternatively, it may be moved to the react-navigation org and I could maintain it. Then it would be okay to link to it, but again, this cannot be applied to all community-developed packages.

Thanks for feedback!