### PR TITLE
fixing broken links

### DIFF
--- a/docs/custom-navigators.md
+++ b/docs/custom-navigators.md
@@ -36,7 +36,7 @@ The navigation prop passed down to a navigator only includes `state` and `dispat
 
 All navigators are controlled components: they always display what is coming in through `props.navigation.state`, and their only way to change the state is to send actions into `props.navigation.dispatch`.
 
-Navigators can specify custom behavior to parent navigators by [customizing their router](/docs/routers/). For example, a navigator is able to specify when actions should be blocked by returning null from `router.getStateForAction`. Or a navigator can specify custom URI handling by overriding `router.getActionForPathAndParams` to output a relevant navigation action, and handling that action in `router.getStateForAction`.
+Navigators can specify custom behavior to parent navigators by [customizing their router](/docs/custom-routers/). For example, a navigator is able to specify when actions should be blocked by returning null from `router.getStateForAction`. Or a navigator can specify custom URI handling by overriding `router.getActionForPathAndParams` to output a relevant navigation action, and handling that action in `router.getStateForAction`.
 
 ### Navigation State
 


### PR DESCRIPTION
Broken `custom-routers` link in `custom-navigation` page