### PR TITLE
Add missing props to AuthLoadingScreen

### DIFF
--- a/docs/auth-flow.md
+++ b/docs/auth-flow.md
@@ -54,8 +54,8 @@ import {
 } from 'react-native';
 
 class AuthLoadingScreen extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this._bootstrapAsync();
   }
 


### PR DESCRIPTION
Otherwise this.props.navigation will not be available in _bootstrapAsync