### PR TITLE
Update navigating-without-navigation-prop.md

### DIFF
--- a/docs/navigating-without-navigation-prop.md
+++ b/docs/navigating-without-navigation-prop.md
@@ -46,7 +46,6 @@ function setTopLevelNavigator(navigatorRef) {
 function navigate(routeName, params) {
   _navigator.dispatch(
     NavigationActions.navigate({
-      type: NavigationActions.NAVIGATE,
       routeName,
       params,
     })


### PR DESCRIPTION
Explicitly stating the action type is actually not needed. `NavigationActions.navigate` already covers that.