### PR TITLE
Add Chinese translation for the some pages

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -6,11 +6,9 @@
  */
 
 const React = require('react');
-// const translate = require("../server/translate.js").translate;
 
 class Footer extends React.Component {
   render() {
-    console.log('this.props.language:', this.props.language)
     const currentYear = new Date().getFullYear();
     return (
       <footer className="nav-footer" id="footer">

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -6,9 +6,11 @@
  */
 
 const React = require('react');
+// const translate = require("../server/translate.js").translate;
 
 class Footer extends React.Component {
   render() {
+    console.log('this.props.language:', this.props.language)
     const currentYear = new Date().getFullYear();
     return (
       <footer className="nav-footer" id="footer">
@@ -25,48 +27,53 @@ class Footer extends React.Component {
             <h5>Docs</h5>
             <a
               href={
-                this.props.config.baseUrl +
-                'docs/getting-started.html'
+                `${this.props.config.baseUrl}docs/${this.props.language}/getting-started.html`
               }>
               Getting Started
             </a>
             <a
               href={
-                this.props.config.baseUrl +
-                'docs/api-reference.html'
+                `${this.props.config.baseUrl}docs/${this.props.language}/api-reference.html`
               }>
               API Reference
             </a>
             <a
               href={
-                this.props.config.baseUrl +
-                'docs/custom-navigator-overview.html'
+                `${this.props.config.baseUrl}docs/${this.props.language}/custom-navigator-overview.html`
               }>
               Building your own Navigator
             </a>
             <a
               href={
-                this.props.config.baseUrl +
-                'docs/contributing.html'
+                `${this.props.config.baseUrl}docs/${this.props.language}/contributing.html`
               }>
               Contributing
             </a>
           </div>
           <div>
             <h5>Support</h5>
-            <a href="https://discord.gg/4xEK3nD">Chat in our Discord channel</a>
-            <a href="https://react-navigation.canny.io/feature-requests">Request a feature on Canny</a>
-            <a href="https://github.com/react-navigation/react-navigation/issues">Report a bug on Github</a>
+            <a href="https://discord.gg/4xEK3nD">
+              Chat in our Discord channel
+            </a>
+            <a href="https://react-navigation.canny.io/feature-requests">
+              Request a feature on Canny
+            </a>
+            <a href="https://github.com/react-navigation/react-navigation/issues">
+              Report a bug on Github
+            </a>
             <a
               href="https://stackoverflow.com/questions/tagged/react-navigation"
-              target="_blank">
+              target="_blank"
+            >
               Get help on Stack Overflow
             </a>
           </div>
           <div>
             <h5>More</h5>
             {/* <a href={this.props.config.baseUrl + 'blog'}>Blog</a> */}
-            <a href={this.props.config.repoUrl}>GitHub</a>
+            <a href={this.props.config.repoUrl}>
+              GitHub
+            </a>
             <a
               className="github-button"
               href={this.props.config.repoUrl}

--- a/website/languages.js
+++ b/website/languages.js
@@ -172,7 +172,7 @@ const languages = [
     tag: 'vi',
   },
   {
-    enabled: false,
+    enabled: true,
     name: '中文',
     tag: 'zh-Hans',
   },

--- a/website/pages/en/help.js
+++ b/website/pages/en/help.js
@@ -7,6 +7,7 @@
 
 const React = require('react');
 
+const translate = require("../../server/translate.js").translate;
 const CompLibrary = require('../../core/CompLibrary.js');
 const Container = CompLibrary.Container;
 const GridBlock = CompLibrary.GridBlock;
@@ -18,17 +19,17 @@ class Help extends React.Component {
     const supportLinks = [
       {
         content:
-          'Learn more using the [documentation on this site.](/docs/getting-started.html) and [reading the API reference](/content/docs/api-reference.html).',
-        title: 'Browse Docs and API',
+          <translate>Learn more using the [documentation on this site.](/docs/getting-started.html) and [reading the API reference](/content/docs/api-reference.html).</translate>,
+        title: <translate>Browse Docs and API</translate>,
       },
       {
-        content: 'Ask questions about the documentation and project in the `#react-navigation` channel on the [Reactiflux Discord](https://discord.gg/4xEK3nD).',
-        title: 'Join the community',
+        content: <translate>Ask questions about the documentation and project in the `#react-navigation` channel on the [Reactiflux Discord](https://discord.gg/4xEK3nD).</translate>,
+        title: <translate>Join the community</translate>,
       },
       {
         content:
-          'Read the release notes for new versions of React Navigation in the [releases tab on the Github repository](https://github.com/react-navigation/react-navigation/releases).',
-        title: 'Stay up to date',
+          <translate>Read the release notes for new versions of React Navigation in the [releases tab on the Github repository](https://github.com/react-navigation/react-navigation/releases).</translate>,
+        title: <translate>Stay up to date</translate>,
       },
     ];
 
@@ -37,18 +38,31 @@ class Help extends React.Component {
         <Container className="mainContainer documentContainer postContainer">
           <div className="post">
             <header className="postHeader">
-              <h2>Need help?</h2>
+              <h2>
+                <translate>Need help?</translate>
+              </h2>
             </header>
             <p>
-              If you've encountered a bug with React Navigation, please{' '}
+              <translate>If you've encountered a bug with React Navigation, please</translate>{' '}
               <a href="https://github.com/react-navigation/react-navigation/issues">
-                post an issue
+                <translate>post an issue</translate>
               </a>{' '}
-              and be sure to fill out the issue template. If you believe there
-              is a feature missing, please <a href="https://react-navigation.canny.io/feature-requests">create a feature request on
-              Canny</a>, or if
-              you're feeling up for the task of proposing an API for the
-              feature, <a href="https://github.com/react-navigation/rfcs">submit a RFC!</a> If you just need some help, try joining us in the <code>#react-navigation</code> channel on <a href="https://discord.gg/4xEK3nD">Discord</a> or <a href="https://stackoverflow.com/questions/tagged/react-navigation">post a question to StackOverflow</a>.
+              <translate>and be sure to fill out the issue template. If you believe there is a feature missing, please</translate>
+              <a href="https://react-navigation.canny.io/feature-requests">
+                <translate>create a feature request on Canny</translate>
+              </a>
+              <translate>, or if you're feeling up for the task of proposing an API for the feature, </translate>
+              <a href="https://github.com/react-navigation/rfcs">
+                <translate>submit a RFC!</translate>
+              </a>
+              <translate>If you just need some help, try joining us in the</translate>
+              <code> react-navigation </code>
+              <translate>channel on</translate>
+              <a href="https://discord.gg/4xEK3nD"> Discord </a>
+              <translate>or</translate>
+              <a href="https://stackoverflow.com/questions/tagged/react-navigation">
+                <translate>post a question to StackOverflow</translate>
+              </a>.
             </p>
             <GridBlock contents={supportLinks} layout="threeColumn" />
           </div>

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -7,6 +7,7 @@
 
 const React = require('react');
 
+const translate = require("../../server/translate.js").translate;
 const CompLibrary = require('../../core/CompLibrary.js');
 const MarkdownBlock = CompLibrary.MarkdownBlock; /* Used to read markdown */
 const Container = CompLibrary.Container;
@@ -48,14 +49,14 @@ class HomeSplash extends React.Component {
               <div className="section promoSection">
                 <div className="promoRow">
                   <div className="pluginRowBlock">
-                    <Button href="/docs/getting-started.html">
-                      Read guides
+                    <Button href={`/docs/${this.props.language}/getting-started.html`}>
+                      <translate>Read guides</translate>
                     </Button>
-                    <Button href="/docs/api-reference.html">
-                      Read API Reference
+                    <Button href={`/docs/${this.props.language}/api-reference.html`}>
+                      <translate>Read API Reference</translate>
                     </Button>
                     <Button href="https://expo.io/@react-navigation/NavigationPlayground">
-                      Try the demo app
+                      <translate>Try the demo app</translate>
                     </Button>
                     {/* <Button href="https://snack.expo.io/@react-navigation/hello-world">Run "Hello World" in Snack</Button> */}
                   </div>
@@ -94,31 +95,31 @@ class Index extends React.Component {
               contents={[
                 {
                   content:
-                    'Start quickly with built-in navigators that deliver a seamless out-of-the-box experience.',
+                    <translate>Start quickly with built-in navigators that deliver a seamless out-of-the-box experience.</translate>,
                   // image: siteConfig.baseUrl + 'img/docusaurus.svg',
                   imageAlign: 'top',
-                  title: 'Easy-to-use',
+                  title: <translate>Easy-to-use</translate>,
                 },
                 {
                   content:
-                    'Platform-specific look-and-feel with smooth animations and gestures.',
+                    <translate>Platform-specific look-and-feel with smooth animations and gestures.</translate>,
                   // image: siteConfig.baseUrl + 'img/docusaurus.svg',
                   imageAlign: 'top',
-                  title: 'Components built for iOS and Android',
+                  title: <translate>Components built for iOS and Android</translate>,
                 },
                 {
                   content:
-                    'If you know how to write apps using JavaScript you can customize any part of React Navigation.',
+                    <translate>If you know how to write apps using JavaScript you can customize any part of React Navigation.</translate>,
                   // image: siteConfig.baseUrl + 'img/docusaurus.svg',
                   imageAlign: 'top',
-                  title: 'Completely customizable',
+                  title: <translate>Completely customizable</translate>,
                 },
                 {
                   content:
-                    "React Navigation is extensible at every layer&mdash; you can write your own navigators or even replace the user-facing API.",
+                    <translate>React Navigation is extensible at every layer&mdash; you can write your own navigators or even replace the user-facing API.</translate>,
                   // image: siteConfig.baseUrl + 'img/docusaurus.svg',
                   imageAlign: 'top',
-                  title: 'Extensible platform',
+                  title: <translate>Extensible platform</translate>,
                 },
               ]}
               layout="fourColumn"


### PR DESCRIPTION
I did a Chinese translation for React Navigation's official website

There are some changes in two pages(main page and help page).
Modified the source code of the three files(index.js,Footer.js and help.js).

**In index.js**
Translated 3 words, modified 3 hyperlinks
[Link](https://github.com/shixiaoquan/react-navigation.github.io/commit/ca927db7d333fc6abd23a75a0f075e187e7dd1e5#diff-cbcca24c9fdb811cd5d539d933af69fb)

**In Footer.js**
Modified 4 hyperlinks
[Link](https://github.com/shixiaoquan/react-navigation.github.io/commit/5d3ecdced6dc77150f8ed21e3edbd5e24b0e94ad#diff-c16bf3020df7b0cc43221c574b1e75e4)

**In help.js**
Modified 17 hyperlinks
[Link](https://github.com/shixiaoquan/react-navigation.github.io/commit/654dacaa41fc7af3a174d678c07d28847f6927e1#diff-13810425449237fc02a4123dfcea619c)
