### PR TITLE
Migrate StackActions to a new page

### DIFF
--- a/docs/navigation-actions.md
+++ b/docs/navigation-actions.md
@@ -15,13 +15,7 @@ The following actions are supported:
 * [Set Params](#setparams) - Set Params for given route
 * [Init](#init) - Used to initialize first state if state is undefined
 
-Within a stack, you can also use:
-
-* [Reset](#reset) - Replace current state with a new state
-* [Replace](#replace) - Replace a route at a given key with another route
-* [Push](#push) - Add a route on the top of the stack, and navigate forward to it
-* [Pop](#pop) - Navigate back to previous routes
-* [PopToTop](#poptotop) - Navigate to the top route of the stack, dismissing all other routes
+For actions specific to a StackNavigator, see [StackActions](stack-actions.html).
 
 The action creator functions define `toString()` to return the action type, which enables easy usage with third-party Redux libraries, including redux-actions and redux-saga.
 
@@ -47,55 +41,6 @@ const navigateAction = NavigationActions.navigate({
 
 this.props.navigation.dispatch(navigateAction);
 ```
-
-### Reset
-
-The `Reset` action wipes the whole navigation state and replaces it with the result of several actions.
-
-* `index` - _number_ - required - Index of the active route on `routes` array in navigation `state`.
-* `actions` - _array_ - required - Array of Navigation Actions that will replace the navigation state.
-* `key` - _string or null_ - optional - If set, the navigator with the given key will reset. If null, the root navigator will reset.
-
-```js
-import { NavigationActions } from 'react-navigation';
-
-const resetAction = NavigationActions.reset({
-  index: 0,
-  actions: [NavigationActions.navigate({ routeName: 'Profile' })],
-});
-this.props.navigation.dispatch(resetAction);
-```
-
-#### How to use the `index` parameter
-
-The `index` param is used to specify the current active route.
-
-eg: given a basic stack navigation with two routes `Profile` and `Settings`.
-To reset the state to a point where the active screen was `Settings` but have it stacked on top of a `Profile` screen, you would do the following:
-
-```js
-import { NavigationActions } from 'react-navigation';
-
-const resetAction = NavigationActions.reset({
-  index: 1,
-  actions: [
-    NavigationActions.navigate({ routeName: 'Profile' }),
-    NavigationActions.navigate({ routeName: 'Settings' }),
-  ],
-});
-this.props.navigation.dispatch(resetAction);
-```
-
-### Replace
-
-The `Replace` action replaces the route at the given key with another route.
-
-* `key` - _string - required - Key of the route to replace.
-* `newKey` - _string - Key to use for the replacement route. Generated automatically if not provided.
-* `routeName` - _string - `routeName` to use for replacement route.
-* `params` - _object_ - Parameters to pass in to the replacement route.
-* `action` - _object_ - Optional sub-action.
-* `immediate`* - _boolean_ - *Currently has no effect*, this is a placeholder for when stack navigator supports animated replace (it currently does not).
 
 ### Back
 

--- a/docs/stack-actions.md
+++ b/docs/stack-actions.md
@@ -1,0 +1,63 @@
+---
+id: stack-actions
+title: StackActions reference
+sidebar_label: StackActions
+---
+
+`StackActions` is an object containing methods for generating actions specific to stack-based navigators. Its methods expand upon the actions available in [NavigationActions](navigation-actions.html).
+
+The following actions are supported:
+* [Reset](#reset) - Replace current state with a new state
+* [Replace](#replace) - Replace a route at a given key with another route
+* [Push](#push) - Add a route on the top of the stack, and navigate forward to it
+* [Pop](#pop) - Navigate back to previous routes
+* [PopToTop](#poptotop) - Navigate to the top route of the stack, dismissing all other routes
+
+### Reset
+
+The `Reset` action wipes the whole navigation state and replaces it with the result of several actions.
+
+* `index` - _number_ - required - Index of the active route on `routes` array in navigation `state`.
+* `actions` - _array_ - required - Array of Navigation Actions that will replace the navigation state.
+* `key` - _string or null_ - optional - If set, the navigator with the given key will reset. If null, the root navigator will reset.
+
+```js
+import { StackActions, NavigationActions } from 'react-navigation';
+
+const resetAction = StackActions.reset({
+  index: 0,
+  actions: [NavigationActions.navigate({ routeName: 'Profile' })],
+});
+this.props.navigation.dispatch(resetAction);
+```
+
+#### How to use the `index` parameter
+
+The `index` param is used to specify the current active route.
+
+eg: given a basic stack navigation with two routes `Profile` and `Settings`.
+To reset the state to a point where the active screen was `Settings` but have it stacked on top of a `Profile` screen, you would do the following:
+
+```js
+import { StackActions, NavigationActions } from 'react-navigation';
+
+const resetAction = StackActions.reset({
+  index: 1,
+  actions: [
+    NavigationActions.navigate({ routeName: 'Profile' }),
+    NavigationActions.navigate({ routeName: 'Settings' }),
+  ],
+});
+this.props.navigation.dispatch(resetAction);
+```
+
+### Replace
+
+The `Replace` action replaces the route at the given key with another route.
+
+* `key` - _string_ - required - Key of the route to replace.
+* `newKey` - _string_ - Key to use for the replacement route. Generated automatically if not provided.
+* `routeName` - _string_ - `routeName` to use for replacement route.
+* `params` - _object_ - Parameters to pass in to the replacement route.
+* `action` - _object_ - Optional sub-action.
+* `immediate`* - _boolean_ - *Currently has no effect*, this is a placeholder for when stack navigator supports animated replace (it currently does not).

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -99,6 +99,8 @@
     "Search screens": "Search screens",
     "set-params-on-back": "Update params when navigating back",
     "Update params when navigating back": "Update params when navigating back",
+    "stack-actions": "StackActions reference",
+    "StackActions": "StackActions",
     "stack-navigator": "createStackNavigator",
     "createStackNavigator": "createStackNavigator",
     "state-persistence": "State persistence",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -42,6 +42,7 @@
       "api-reference",
       "navigation-prop",
       "navigation-actions",
+      "stack-actions",
       "stack-navigator",
       "switch-navigator",
       "drawer-navigator",


### PR DESCRIPTION
Since https://github.com/react-navigation/react-navigation/pull/3619, actions for stack navigators have moved to the `StackActions` object, so the documentation for `replace` and `reset` needed an update. 
For the most part, it's a direct swap of the StackActions content into a new page, with a few additional changes:
* Examples now show `StackActions` being imported and used as well as `NavigationActions`
* Fixed italics on prop types in a few examples
* Added an intro for StackActions and links between the two pages. 

Happy to make additional changes if there's anything missing/unclear. Thanks again for all your work on this project! 

_Note_: I haven't yet added additional docs for `Push`, `Pop` or `PopToTop`. 