### PR TITLE
Added section about community navigators

### DIFF
--- a/docs/community-fluidtransitions.md
+++ b/docs/community-fluidtransitions.md
@@ -1,0 +1,24 @@
+---
+id: community-fluidtransitions
+title: Fluid Transitions
+sidebar_label: Fluid Transitions
+---
+
+Fluid Transitions is a library that provides Shared Element Transitions during navigation between screens using react-navigation. 
+
+A Shared Element Transition is the visualization of an element in one screen being transformed into a corresponding element in another screen during the navigation transition.
+
+The library implements a custom navigator called `FluidNavigator` that makes all this and more possible. 
+
+## Installation
+
+Install the FluidTransitions package in your project:
+
+```
+nmp install react-navigation-fluid-transitions
+yarn install  react-navigation-fluid-transitions
+```
+
+## Links
+
+[https://github.com/fram-x/FluidTransitions](https://github.com/fram-x/FluidTransitions)

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -16,6 +16,8 @@
     "createBottomTabNavigator": "createBottomTabNavigator",
     "common-mistakes": "Common mistakes",
     "Common mistakes": "Common mistakes",
+    "community-fluidtransitions": "Fluid Transitions",
+    "Fluid Transitions": "Fluid Transitions",
     "composing-navigators": "Adding tabs",
     "Adding tabs": "Adding tabs",
     "connecting-navigation-prop": "Access the navigation prop from any component",
@@ -128,6 +130,7 @@
     "Fundamentals": "Fundamentals",
     "Assorted Guides": "Assorted Guides",
     "Build your own Navigator": "Build your own Navigator",
+    "Community Navigators": "Community Navigators",
     "Meta": "Meta",
     "API Reference": "API Reference"
   },

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -37,6 +37,9 @@
       "navigation-views",
       "transitioner"
     ],
+    "Community Navigators": [      
+      "community-fluidtransitions"
+    ],
     "Meta": ["pitch", "alternatives", "contributing"]
   },
   "api": {


### PR DESCRIPTION
**Motivation**
React Navigation can be extended with custom navigators, and it would be cool to add a section in the documentation about this (idea from: @brentvatne)

**Description**
This pull request contains a new section in the sidebar titled "Community Navigators" and a document with a short introduction about Fluid Transitions. I'm not sure about how complex we want these descriptions to be, but I decided to keep example code out so that we won't need to update the documentation for external projects like this.

**Changes**
- Added section in sidebars.json
- Added community navigator Fluid Transitions