### PR TITLE
Update the quotes in the documentation to be consistent

### DIFF
--- a/docs/navigation-options-resolution.md
+++ b/docs/navigation-options-resolution.md
@@ -92,7 +92,7 @@ const HomeStack = createStackNavigator({ A }, {
   // This is the default for screens in the stack, so `A` will
   // use this title unless it overrides it
   navigationOptions: {
-    title: 'Welcome"
+    title: 'Welcome'
   }
 })
 


### PR DESCRIPTION
Update the quotes around `Welcome` to be consistent so it's valid to copy/paste.