### PR TITLE
Update header-buttons.md

### DIFF
--- a/docs/header-buttons.md
+++ b/docs/header-buttons.md
@@ -42,7 +42,7 @@ class HomeScreen extends React.Component {
       headerTitle: <LogoTitle />,
       headerRight: (
         <Button
-          onPress={navigation.getParam('increaseCount')}
+          onPress={async () => await navigation.getParam('increaseCount')}
           title="+1"
           color="#fff"
         />


### PR DESCRIPTION
Doing onPress={async () => await navigation.getParam('increaseCount')} instead of onPress={navigation.getParam('increaseCount')} prevents next warning to be thrown: Warning: Failed prop type: The prop `onPress` is marked as required in `Button`, but its value is `undefined`.