### PR TITLE
withNavigation docs: add note about the onRef property

### DIFF
--- a/docs/with-navigation.md
+++ b/docs/with-navigation.md
@@ -25,3 +25,15 @@ class MyBackButton extends React.Component {
 // navigation prop
 export default withNavigation(MyBackButton);
 ```
+
+## Notes
+
+- If you wish to use the `ref` prop on the wrapped component, you must pass the `onRef` prop instead. For example,
+
+```
+// MyBackButton.ts
+export default withNavigation(MyBackButton);
+
+// MyNavBar.ts
+<MyBackButton onRef={(elem) => this.backButton = elem} />
+```


### PR DESCRIPTION
The onRef property was added to allow for passing refs to components wrapped by `withNavigation`, as seen in this PR: https://github.com/react-navigation/react-navigation/issues/3461

However, it's not documented. This adds docs.

Corresponding change to typings here: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/26714