### PR TITLE
Update deep-linking.md

### DIFF
--- a/docs/deep-linking.md
+++ b/docs/deep-linking.md
@@ -38,6 +38,7 @@ Next, let's configure our navigation container to extract the path from the app'
 const SimpleApp = createStackNavigator({...});
 
 // on Android, the URI prefix typically contains a host in addition to scheme
+// on Android, note the required / (slash) at the end of the host property
 const prefix = Platform.OS == 'android' ? 'mychat://mychat/' : 'mychat://';
 
 const MainApp = () => <SimpleApp uriPrefix={prefix} />;


### PR DESCRIPTION
Without / after the host property nested deep linking doesn't work.