### PR TITLE
Add <NavigationEvents/> to doc

### DIFF
--- a/docs/navigation-events.md
+++ b/docs/navigation-events.md
@@ -1,0 +1,41 @@
+---
+id: navigation-events
+title: NavigationEvents reference
+sidebar_label: NavigationEvents
+---
+
+`NavigationEvents` is a React component providing a declarative API to subscribe to navigation events. It will subscribe to navigation events on mount, and unsubscribe on unmount.
+
+### Component props
+
+* `navigation` - navigation props (optional, defaults to reading from React context)
+* `onWillFocus` - event listener
+* `onDidFocus` - event listener
+* `onWillBlur` - event listener
+* `onDidBlur`: event listener
+
+The event listener is the same as the imperative [`navigation.addListener(...)`](navigation-prop.html#addlistener-subscribe-to-updates-to-navigation-lifecycle) API.
+
+### Example
+
+```jsx harmony
+import React from 'react';
+import { View } from 'react-native';
+import { NavigationEvents } from 'react-navigation';
+
+const MyScreen = () => (
+  <View>
+    <NavigationEvents
+      onWillFocus={payload => console.log('will focus',payload)}
+      onDidFocus={payload => console.log('did focus',payload)}
+      onWillBlur={payload => console.log('will blur',payload)}
+      onDidBlur={payload => console.log('did blur',payload)}
+    />
+    {/* 
+      Your view code
+    */}
+  </View>
+);
+
+export default MyScreen;
+```

--- a/docs/navigation-events.md
+++ b/docs/navigation-events.md
@@ -12,7 +12,7 @@ sidebar_label: NavigationEvents
 * `onWillFocus` - event listener
 * `onDidFocus` - event listener
 * `onWillBlur` - event listener
-* `onDidBlur`: event listener
+* `onDidBlur` - event listener
 
 The event listener is the same as the imperative [`navigation.addListener(...)`](navigation-prop.html#addlistener-subscribe-to-updates-to-navigation-lifecycle) API.
 

--- a/docs/navigation-prop.md
+++ b/docs/navigation-prop.md
@@ -138,6 +138,8 @@ The JSON payload:
 };
 ```
 
+You can also subscribe to navigation events declaratively with the [`<NavigationEvents/>`]((navigation-events.html)) component.
+
 ### `isFocused` - Query the focused state of the screen
 
 Returns `true` if the screen is focused and `false` otherwise.


### PR DESCRIPTION
This is a first version of `<NavigationEvents/>` doc.

@brentvatne I wasn't able to add it to sidebar, maybe because of missing i18n key in crowdin? 

Not sure how this all works, tried to copy what you did for `withNavigationFocus` but got this error:

> Error: Improper sidebars.json file, document with id 'en-NavigationEvents' not found. Make sure that documents with the ids specified in sidebars.json exist and that no ids are repeated.
