### PR TITLE
camelCase navigation actions methods

### DIFF
--- a/docs/navigation-actions.md
+++ b/docs/navigation-actions.md
@@ -19,9 +19,9 @@ For actions specific to a StackNavigator, see [StackActions](stack-actions.html)
 
 The action creator functions define `toString()` to return the action type, which enables easy usage with third-party Redux libraries, including redux-actions and redux-saga.
 
-### Navigate
+### navigate
 
-The `navigate` action will update the current state with the result of a `Navigate` action.
+The `navigate` action will update the current state with the result of a `navigate` action.
 
 * `routeName` - _String_ - Required - A destination routeName that has been registered somewhere in the app's router
 * `params` - _Object_ - Optional - Params to merge into the destination route
@@ -59,7 +59,7 @@ this.props.navigation.dispatch(backAction);
 
 ### setParams
 
-When dispatching `SetParams`, the router will produce a new state that has changed the params of a particular route, as identified by the key
+When dispatching `setParams`, the router will produce a new state that has changed the params of a particular route, as identified by the key
 
 * `params` - _object_ - required - New params to be merged into existing route params
 * `key` - _string_ - required - Route key that should get the new params

--- a/docs/navigation-actions.md
+++ b/docs/navigation-actions.md
@@ -21,7 +21,7 @@ The action creator functions define `toString()` to return the action type, whic
 
 ### Navigate
 
-The `Navigate` action will update the current state with the result of a `Navigate` action.
+The `navigate` action will update the current state with the result of a `Navigate` action.
 
 * `routeName` - _String_ - Required - A destination routeName that has been registered somewhere in the app's router
 * `params` - _Object_ - Optional - Params to merge into the destination route
@@ -42,7 +42,7 @@ const navigateAction = NavigationActions.navigate({
 this.props.navigation.dispatch(navigateAction);
 ```
 
-### Back
+### back
 
 Go back to previous screen and close current screen. `back` action creator takes in one optional parameter:
 
@@ -57,7 +57,7 @@ const backAction = NavigationActions.back({
 this.props.navigation.dispatch(backAction);
 ```
 
-### SetParams
+### setParams
 
 When dispatching `SetParams`, the router will produce a new state that has changed the params of a particular route, as identified by the key
 


### PR DESCRIPTION
In order to avoid confusion the navigation actions methods should be camelCase