### PR TITLE
Fix links to extracted StackView components

### DIFF
--- a/docs/navigation-views.md
+++ b/docs/navigation-views.md
@@ -10,9 +10,9 @@ Navigation views are controlled React components that can present the current na
 
 ## Built in Views
 
-- [StackView](https://github.com/react-navigation/react-navigation/blob/master/src/views/StackView/StackView.js) - Present a stack that looks suitable on any platform
-    + [StackViewCard](https://github.com/react-navigation/react-navigation/blob/master/src/views/StackView/StackViewCard.js) - Present one card from the card stack, with gestures
-    + [Header](https://github.com/react-community/react-navigation/blob/master/src/views/Header/Header.js) - The header view for the card stack
+- [StackView](https://github.com/react-navigation/react-navigation-stack/blob/master/src/views/StackView/StackView.js) - Present a stack that looks suitable on any platform
+    + [StackViewCard](https://github.com/react-navigation/react-navigation-stack/blob/master/src/views/StackView/StackViewCard.js) - Present one card from the card stack, with gestures
+    + [Header](https://github.com/react-navigation/react-navigation-stack/blob/master/src/views/Header/Header.js) - The header view for the card stack
 - [SwitchView](https://github.com/react-navigation/react-navigation/blob/master/src/views/SwitchView/SwitchView.js) - A navigator that only ever show one screen at a time, useful for authentication flows.
 - [Tabs](https://github.com/react-navigation/react-navigation-tabs) - A configurable tab switcher / pager
 - [Drawer](https://github.com/react-navigation/react-navigation-drawer) - A view with a drawer that slides from the left


### PR DESCRIPTION
Fix not working (404) links on https://reactnavigation.org/docs/en/navigation-views.html

The new links refers to https://github.com/react-navigation/react-navigation-stack