### PR TITLE
Add a space to make js formatting consistent in navigation options docs

### DIFF
--- a/docs/stack-navigator.md
+++ b/docs/stack-navigator.md
@@ -235,7 +235,7 @@ You can view these examples directly on your phone by visiting [our expo demo](h
 #### Modal StackNavigator with Custom Screen Transitions
 
 ```js
-const ModalNavigator =createStackNavigator(
+const ModalNavigator = createStackNavigator(
   {
     Main: { screen: Main },
     Login: { screen: Login },


### PR DESCRIPTION
I know it's just a space but it bugged me enough to open a PR. 🐰 