### PR TITLE
Update material-top-tab-navigator.md

### DIFF
--- a/docs/material-top-tab-navigator.md
+++ b/docs/material-top-tab-navigator.md
@@ -54,7 +54,7 @@ tabBarOptions: {
     width: 100,
   },
   indicatorStyle: {
-    width: 100
+    width: 100,
     left: '12.5%' // This will center the indicator (Assuming 2 tabs) as it's position is absolute across the whole tab!
   },
   style: {


### PR DESCRIPTION
**Motivation**
There is no easy way to center the indicator or any supporting documentation. I suggest a re-write of the component to not use Absolute for positioning but this will do for now in helping the majority of people (As seen in the official Discord channel who could still not solve this).