### PR TITLE
Add resolution to dynamically set the mode for a transition

### DIFF
--- a/docs/navigation-options-resolution.md
+++ b/docs/navigation-options-resolution.md
@@ -312,3 +312,31 @@ const AppNavigator = createSwitchNavigator({
   Home: HomeStack,
 });
 ```
+
+# A stack has more than one screen and you want to specify the transition mode for each screen explicitly
+
+We can’t set the `StackNavigatorConfig`’s `mode` dynamically. Instead we are going to use a custom `transitionConfig` to render the specfific transition we want - modal or card - on a screen by screen basis.
+
+```js
+  import { createStackNavigator, StackViewTransitionConfigs } from "react-navigation";
+
+  /* The screens you add to IOS_MODAL_ROUTES will have the modal transition.  */
+  const IOS_MODAL_ROUTES = ["OptionsScreen"];
+
+  let dynamicModalTransition = (transitionProps, prevTransitionProps) => {
+    return StackViewTransitionConfigs.defaultTransitionConfig(
+      transitionProps,
+      prevTransitionProps,
+      IOS_MODAL_ROUTES.some(
+        screenName =>
+          screenName === transitionProps.scene.route.routeName ||
+          (prevTransitionProps && screenName === prevTransitionProps.scene.route.routeName)
+      )
+    );
+  };
+
+  const HomeStack = createStackNavigator(
+    { DetailScreen, HomeScreen, OptionsScreen },
+    { initialRouteName: "HomeScreen", transitionConfig: dynamicModalTransition }
+  );
+```

--- a/docs/navigation-options-resolution.md
+++ b/docs/navigation-options-resolution.md
@@ -15,7 +15,7 @@ Let's take for example a tab navigator that contains a stack in each tab. What h
 ```js
 class A extends React.Component {
   static navigationOptions = {
-    tabBarLabel: "Home!"
+    tabBarLabel: 'Home!',
   };
 
   // etc..
@@ -23,7 +23,7 @@ class A extends React.Component {
 
 class B extends React.Component {
   static navigationOptions = {
-    tabBarLabel: "Settings!"
+    tabBarLabel: 'Settings!',
   };
 
   // etc..
@@ -34,7 +34,7 @@ const SettingsStack = createStackNavigator({ B });
 
 export default createBottomTabNavigator({
   HomeStack,
-  SettingsStack
+  SettingsStack,
 });
 ```
 
@@ -47,16 +47,16 @@ const HomeStack = createStackNavigator({ A });
 const SettingsStack = createStackNavigator({ B });
 
 HomeStack.navigationOptions = {
-  tabBarLabel: "Home!"
+  tabBarLabel: 'Home!',
 };
 
 SettingsStack.navigationOptions = {
-  tabBarLabel: "Settings!"
+  tabBarLabel: 'Settings!',
 };
 
 export default createBottomTabNavigator({
   HomeStack,
-  SettingsStack
+  SettingsStack,
 });
 ```
 
@@ -67,7 +67,7 @@ To understand what is going on here, first recall that in the following example,
 ```js
 class MyComponent extends React.Component {
   static navigationOptions = {
-    title: "Hello!"
+    title: 'Hello!',
   };
   // etc.
 }
@@ -77,7 +77,7 @@ class MyOtherComponent extends React.Component {
 }
 
 MyOtherComponent.navigationOptions = {
-  title: "Hello!"
+  title: 'Hello!',
 };
 ```
 
@@ -88,21 +88,18 @@ We also know that `createStackNavigator` and related functions return React comp
 Navigators are initialized with `create*Navigator(routeConfig, navigatorConfig)`. Inside of `navigatorConfig` we can add a `navigationOptions` property. These `navigationOptions` are the default options for screens within that navigator ([read more about sharing common navigationOptions](headers.html#sharing-common-navigationoptions-across-screens)), they do not refer to the `navigationOptions` for that navigator &mdash; as we have seen above, we set the `navigationOptions` property directly on the navigator for that use case.
 
 ```js
-const HomeStack = createStackNavigator(
-  { A },
-  {
-    // This is the default for screens in the stack, so `A` will
-    // use this title unless it overrides it
-    navigationOptions: {
-      title: "Welcome"
-    }
+const HomeStack = createStackNavigator({ A }, {
+  // This is the default for screens in the stack, so `A` will
+  // use this title unless it overrides it
+  navigationOptions: {
+    title: 'Welcome'
   }
-);
+})
 
 // These are the options that are used by the navigator that renders
 // the HomeStack, in our example above this is a tab navigator.
 HomeStack.navigationOptions = {
-  tabBarLabel: "Home!"
+  tabBarLabel: 'Home!',
 };
 ```
 
@@ -115,12 +112,12 @@ Imagine the following configuration:
 ```js
 const TabNavigator = createBottomTabNavigator({
   Feed: FeedScreen,
-  Profile: ProfileScreen
+  Profile: ProfileScreen,
 });
 
 const AppNavigator = createStackNavigator({
   Home: TabNavigator,
-  Settings: SettingsScreen
+  Settings: SettingsScreen,
 });
 ```
 
@@ -129,7 +126,7 @@ If we were to set the `headerTitle` with `navigationOptions` on the `FeedScreen`
 ```js
 const TabNavigator = createBottomTabNavigator({
   Feed: FeedScreen,
-  Profile: ProfileScreen
+  Profile: ProfileScreen,
 });
 
 TabNavigator.navigationOptions = ({ navigation }) => {
@@ -139,7 +136,7 @@ TabNavigator.navigationOptions = ({ navigation }) => {
   const headerTitle = routeName;
 
   return {
-    headerTitle
+    headerTitle,
   };
 };
 ```
@@ -148,28 +145,28 @@ Another option is to re-organize your navigators, such that each tab has its own
 
 ```js
 const FeedStack = createStackNavigator({
-  FeedHome: FeedScreen
+  FeedHome: FeedScreen,
   /* other routes here */
 });
 
 const ProfileStack = createStackNavigator({
-  ProfileHome: ProfileScreen
+  ProfileHome: ProfileScreen,
   /* other routes here */
 });
 
 const TabNavigator = createBottomTabNavigator({
   Feed: FeedStack,
-  Profile: ProfileStack
+  Profile: ProfileStack,
 });
 
 TabNavigator.navigationOptions = {
   // Hide the header from AppNavigator stack
-  header: null
+  header: null,
 };
 
 const AppNavigator = createStackNavigator({
   Home: TabNavigator,
-  Settings: SettingsScreen
+  Settings: SettingsScreen,
 });
 ```
 
@@ -186,17 +183,17 @@ Imagine the following configuration:
 ```js
 const FeedStack = createStackNavigator({
   FeedHome: FeedScreen,
-  Details: DetailsScreen
+  Details: DetailsScreen,
 });
 
 const TabNavigator = createBottomTabNavigator({
   Feed: FeedStack,
-  Profile: ProfileScreen
+  Profile: ProfileScreen,
 });
 
 const AppNavigator = createSwitchNavigator({
   Auth: AuthScreen,
-  Home: TabNavigator
+  Home: TabNavigator,
 });
 ```
 
@@ -205,7 +202,7 @@ If we want to hide the tab bar when we navigate from the feed home to a details 
 ```js
 const FeedStack = createStackNavigator({
   FeedHome: FeedScreen,
-  Details: DetailsScreen
+  Details: DetailsScreen,
 });
 
 FeedStack.navigationOptions = ({ navigation }) => {
@@ -215,7 +212,7 @@ FeedStack.navigationOptions = ({ navigation }) => {
   }
 
   return {
-    tabBarVisible
+    tabBarVisible,
   };
 };
 ```
@@ -226,24 +223,24 @@ Another option here would be to add another stack navigator as a parent of the t
 
 ```js
 const FeedStack = createStackNavigator({
-  FeedHome: FeedScreen
+  FeedHome: FeedScreen,
   /* any other route you want to render under the tab bar */
 });
 
 const TabNavigator = createBottomTabNavigator({
   Feed: FeedStack,
-  Profile: ProfileScreen
+  Profile: ProfileScreen,
 });
 
 const HomeStack = createStackNavigator({
   Tabs: TabNavigator,
-  Details: DetailsScreen
+  Details: DetailsScreen,
   /* any other route you want to render above the tab bar */
 });
 
 const AppNavigator = createSwitchNavigator({
   Auth: AuthScreen,
-  Home: HomeStack
+  Home: HomeStack,
 });
 ```
 
@@ -256,17 +253,17 @@ Imagine the following configuration:
 ```js
 const FeedStack = createStackNavigator({
   FeedHome: FeedScreen,
-  Details: DetailsScreen
+  Details: DetailsScreen,
 });
 
 const DrawerNavigator = createDrawerNavigator({
   Feed: FeedStack,
-  Profile: ProfileScreen
+  Profile: ProfileScreen,
 });
 
 const AppNavigator = createSwitchNavigator({
   Auth: AuthScreen,
-  Home: DrawerNavigator
+  Home: DrawerNavigator,
 });
 ```
 
@@ -275,17 +272,17 @@ In order to hide the drawer when we push the details screen to the feed stack, w
 ```js
 const FeedStack = createStackNavigator({
   FeedHome: FeedScreen,
-  Details: DetailsScreen
+  Details: DetailsScreen,
 });
 
 FeedStack.navigationOptions = ({ navigation }) => {
-  let drawerLockMode = "unlocked";
+  let drawerLockMode = 'unlocked';
   if (navigation.state.index > 0) {
-    drawerLockMode = "locked-closed";
+    drawerLockMode = 'locked-closed';
   }
 
   return {
-    drawerLockMode
+    drawerLockMode,
   };
 };
 ```
@@ -294,24 +291,24 @@ Another option here would be to add another stack navigator as a parent of the d
 
 ```js
 const FeedStack = createStackNavigator({
-  FeedHome: FeedScreen
+  FeedHome: FeedScreen,
   /* any other route where you want the drawer to remain available */
   /* keep in mind that it will conflict with the swipe back gesture on ios */
 });
 
 const DrawerNavigator = createDrawerNavigator({
   Feed: FeedStack,
-  Profile: ProfileScreen
+  Profile: ProfileScreen,
 });
 
 const HomeStack = createStackNavigator({
   Drawer: DrawerNavigator,
-  Details: DetailsScreen
+  Details: DetailsScreen,
   /* add routes here where you want the drawer to be locked */
 });
 
 const AppNavigator = createSwitchNavigator({
   Auth: AuthScreen,
-  Home: HomeStack
+  Home: HomeStack,
 });
 ```

--- a/docs/navigation-options-resolution.md
+++ b/docs/navigation-options-resolution.md
@@ -15,7 +15,7 @@ Let's take for example a tab navigator that contains a stack in each tab. What h
 ```js
 class A extends React.Component {
   static navigationOptions = {
-    tabBarLabel: 'Home!',
+    tabBarLabel: "Home!"
   };
 
   // etc..
@@ -23,7 +23,7 @@ class A extends React.Component {
 
 class B extends React.Component {
   static navigationOptions = {
-    tabBarLabel: 'Settings!',
+    tabBarLabel: "Settings!"
   };
 
   // etc..
@@ -34,7 +34,7 @@ const SettingsStack = createStackNavigator({ B });
 
 export default createBottomTabNavigator({
   HomeStack,
-  SettingsStack,
+  SettingsStack
 });
 ```
 
@@ -47,16 +47,16 @@ const HomeStack = createStackNavigator({ A });
 const SettingsStack = createStackNavigator({ B });
 
 HomeStack.navigationOptions = {
-  tabBarLabel: 'Home!',
+  tabBarLabel: "Home!"
 };
 
 SettingsStack.navigationOptions = {
-  tabBarLabel: 'Settings!',
+  tabBarLabel: "Settings!"
 };
 
 export default createBottomTabNavigator({
   HomeStack,
-  SettingsStack,
+  SettingsStack
 });
 ```
 
@@ -67,7 +67,7 @@ To understand what is going on here, first recall that in the following example,
 ```js
 class MyComponent extends React.Component {
   static navigationOptions = {
-    title: 'Hello!',
+    title: "Hello!"
   };
   // etc.
 }
@@ -77,7 +77,7 @@ class MyOtherComponent extends React.Component {
 }
 
 MyOtherComponent.navigationOptions = {
-  title: 'Hello!',
+  title: "Hello!"
 };
 ```
 
@@ -88,18 +88,21 @@ We also know that `createStackNavigator` and related functions return React comp
 Navigators are initialized with `create*Navigator(routeConfig, navigatorConfig)`. Inside of `navigatorConfig` we can add a `navigationOptions` property. These `navigationOptions` are the default options for screens within that navigator ([read more about sharing common navigationOptions](headers.html#sharing-common-navigationoptions-across-screens)), they do not refer to the `navigationOptions` for that navigator &mdash; as we have seen above, we set the `navigationOptions` property directly on the navigator for that use case.
 
 ```js
-const HomeStack = createStackNavigator({ A }, {
-  // This is the default for screens in the stack, so `A` will
-  // use this title unless it overrides it
-  navigationOptions: {
-    title: 'Welcome'
+const HomeStack = createStackNavigator(
+  { A },
+  {
+    // This is the default for screens in the stack, so `A` will
+    // use this title unless it overrides it
+    navigationOptions: {
+      title: "Welcome"
+    }
   }
-})
+);
 
 // These are the options that are used by the navigator that renders
 // the HomeStack, in our example above this is a tab navigator.
 HomeStack.navigationOptions = {
-  tabBarLabel: 'Home!',
+  tabBarLabel: "Home!"
 };
 ```
 
@@ -112,12 +115,12 @@ Imagine the following configuration:
 ```js
 const TabNavigator = createBottomTabNavigator({
   Feed: FeedScreen,
-  Profile: ProfileScreen,
+  Profile: ProfileScreen
 });
 
 const AppNavigator = createStackNavigator({
   Home: TabNavigator,
-  Settings: SettingsScreen,
+  Settings: SettingsScreen
 });
 ```
 
@@ -126,7 +129,7 @@ If we were to set the `headerTitle` with `navigationOptions` on the `FeedScreen`
 ```js
 const TabNavigator = createBottomTabNavigator({
   Feed: FeedScreen,
-  Profile: ProfileScreen,
+  Profile: ProfileScreen
 });
 
 TabNavigator.navigationOptions = ({ navigation }) => {
@@ -136,7 +139,7 @@ TabNavigator.navigationOptions = ({ navigation }) => {
   const headerTitle = routeName;
 
   return {
-    headerTitle,
+    headerTitle
   };
 };
 ```
@@ -145,28 +148,28 @@ Another option is to re-organize your navigators, such that each tab has its own
 
 ```js
 const FeedStack = createStackNavigator({
-  FeedHome: FeedScreen,
+  FeedHome: FeedScreen
   /* other routes here */
 });
 
 const ProfileStack = createStackNavigator({
-  ProfileHome: ProfileScreen,
+  ProfileHome: ProfileScreen
   /* other routes here */
 });
 
 const TabNavigator = createBottomTabNavigator({
   Feed: FeedStack,
-  Profile: ProfileStack,
+  Profile: ProfileStack
 });
 
 TabNavigator.navigationOptions = {
   // Hide the header from AppNavigator stack
-  header: null,
+  header: null
 };
 
 const AppNavigator = createStackNavigator({
   Home: TabNavigator,
-  Settings: SettingsScreen,
+  Settings: SettingsScreen
 });
 ```
 
@@ -183,17 +186,17 @@ Imagine the following configuration:
 ```js
 const FeedStack = createStackNavigator({
   FeedHome: FeedScreen,
-  Details: DetailsScreen,
+  Details: DetailsScreen
 });
 
 const TabNavigator = createBottomTabNavigator({
   Feed: FeedStack,
-  Profile: ProfileScreen,
+  Profile: ProfileScreen
 });
 
 const AppNavigator = createSwitchNavigator({
   Auth: AuthScreen,
-  Home: TabNavigator,
+  Home: TabNavigator
 });
 ```
 
@@ -202,7 +205,7 @@ If we want to hide the tab bar when we navigate from the feed home to a details 
 ```js
 const FeedStack = createStackNavigator({
   FeedHome: FeedScreen,
-  Details: DetailsScreen,
+  Details: DetailsScreen
 });
 
 FeedStack.navigationOptions = ({ navigation }) => {
@@ -212,7 +215,7 @@ FeedStack.navigationOptions = ({ navigation }) => {
   }
 
   return {
-    tabBarVisible,
+    tabBarVisible
   };
 };
 ```
@@ -223,24 +226,24 @@ Another option here would be to add another stack navigator as a parent of the t
 
 ```js
 const FeedStack = createStackNavigator({
-  FeedHome: FeedScreen,
+  FeedHome: FeedScreen
   /* any other route you want to render under the tab bar */
 });
 
 const TabNavigator = createBottomTabNavigator({
   Feed: FeedStack,
-  Profile: ProfileScreen,
+  Profile: ProfileScreen
 });
 
 const HomeStack = createStackNavigator({
   Tabs: TabNavigator,
-  Details: DetailsScreen,
+  Details: DetailsScreen
   /* any other route you want to render above the tab bar */
 });
 
 const AppNavigator = createSwitchNavigator({
   Auth: AuthScreen,
-  Home: HomeStack,
+  Home: HomeStack
 });
 ```
 
@@ -253,17 +256,17 @@ Imagine the following configuration:
 ```js
 const FeedStack = createStackNavigator({
   FeedHome: FeedScreen,
-  Details: DetailsScreen,
+  Details: DetailsScreen
 });
 
 const DrawerNavigator = createDrawerNavigator({
   Feed: FeedStack,
-  Profile: ProfileScreen,
+  Profile: ProfileScreen
 });
 
 const AppNavigator = createSwitchNavigator({
   Auth: AuthScreen,
-  Home: DrawerNavigator,
+  Home: DrawerNavigator
 });
 ```
 
@@ -272,17 +275,17 @@ In order to hide the drawer when we push the details screen to the feed stack, w
 ```js
 const FeedStack = createStackNavigator({
   FeedHome: FeedScreen,
-  Details: DetailsScreen,
+  Details: DetailsScreen
 });
 
 FeedStack.navigationOptions = ({ navigation }) => {
-  let drawerLockMode = 'unlocked';
+  let drawerLockMode = "unlocked";
   if (navigation.state.index > 0) {
-    drawerLockMode = 'locked-closed';
+    drawerLockMode = "locked-closed";
   }
 
   return {
-    drawerLockMode,
+    drawerLockMode
   };
 };
 ```
@@ -291,52 +294,24 @@ Another option here would be to add another stack navigator as a parent of the d
 
 ```js
 const FeedStack = createStackNavigator({
-  FeedHome: FeedScreen,
+  FeedHome: FeedScreen
   /* any other route where you want the drawer to remain available */
   /* keep in mind that it will conflict with the swipe back gesture on ios */
 });
 
 const DrawerNavigator = createDrawerNavigator({
   Feed: FeedStack,
-  Profile: ProfileScreen,
+  Profile: ProfileScreen
 });
 
 const HomeStack = createStackNavigator({
   Drawer: DrawerNavigator,
-  Details: DetailsScreen,
+  Details: DetailsScreen
   /* add routes here where you want the drawer to be locked */
 });
 
 const AppNavigator = createSwitchNavigator({
   Auth: AuthScreen,
-  Home: HomeStack,
+  Home: HomeStack
 });
-```
-
-# A stack has more than one screen and you want to specify the transition mode for each screen explicitly
-
-We can’t set the `StackNavigatorConfig`’s `mode` dynamically. Instead we are going to use a custom `transitionConfig` to render the specfific transition we want - modal or card - on a screen by screen basis.
-
-```js
-  import { createStackNavigator, StackViewTransitionConfigs } from "react-navigation";
-
-  /* The screens you add to IOS_MODAL_ROUTES will have the modal transition.  */
-  const IOS_MODAL_ROUTES = ["OptionsScreen"];
-
-  let dynamicModalTransition = (transitionProps, prevTransitionProps) => {
-    return StackViewTransitionConfigs.defaultTransitionConfig(
-      transitionProps,
-      prevTransitionProps,
-      IOS_MODAL_ROUTES.some(
-        screenName =>
-          screenName === transitionProps.scene.route.routeName ||
-          (prevTransitionProps && screenName === prevTransitionProps.scene.route.routeName)
-      )
-    );
-  };
-
-  const HomeStack = createStackNavigator(
-    { DetailScreen, HomeScreen, OptionsScreen },
-    { initialRouteName: "HomeScreen", transitionConfig: dynamicModalTransition }
-  );
 ```

--- a/docs/stack-navigator.md
+++ b/docs/stack-navigator.md
@@ -278,7 +278,7 @@ Header transitions can also be configured using `headerLeftInterpolator`, `heade
 
 #### Specifying the transition mode for a stack's screens explicitly
 
-We can’t set the `StackNavigatorConfig`’s `mode` dynamically. Instead we are going to use a custom `transitionConfig` to render the specfific transition we want - modal or card - on a screen by screen basis.
+We can't set the `StackNavigatorConfig`'s `mode` dynamically. Instead we are going to use a custom `transitionConfig` to render the specfific transition we want - modal or card - on a screen by screen basis.
 
 ```js
 import { createStackNavigator, StackViewTransitionConfigs } from 'react-navigation';
@@ -287,14 +287,15 @@ import { createStackNavigator, StackViewTransitionConfigs } from 'react-navigati
 const IOS_MODAL_ROUTES = ['OptionsScreen'];
 
 let dynamicModalTransition = (transitionProps, prevTransitionProps) => {
+  const isModal = IOS_MODAL_ROUTES.some(
+    screenName =>
+      screenName === transitionProps.scene.route.routeName ||
+      (prevTransitionProps && screenName === prevTransitionProps.scene.route.routeName)
+  )
   return StackViewTransitionConfigs.defaultTransitionConfig(
     transitionProps,
     prevTransitionProps,
-    IOS_MODAL_ROUTES.some(
-      screenName =>
-        screenName === transitionProps.scene.route.routeName ||
-        (prevTransitionProps && screenName === prevTransitionProps.scene.route.routeName)
-    )
+    isModal
   );
 };
 

--- a/docs/stack-navigator.md
+++ b/docs/stack-navigator.md
@@ -27,16 +27,16 @@ createStackNavigator({
     // When `ProfileScreen` is loaded by the StackNavigator, it will be given a `navigation` prop.
 
     // Optional: When deep linking or using react-navigation in a web app, this path is used:
-    path: "people/:name",
+    path: 'people/:name',
     // The action and route params are extracted from the path.
 
     // Optional: Override the `navigationOptions` for the screen
     navigationOptions: ({ navigation }) => ({
-      title: `${navigation.state.params.name}'s Profile'`
-    })
+      title: `${navigation.state.params.name}'s Profile'`,
+    }),
   },
 
-  ...MyOtherRoutes
+  ...MyOtherRoutes,
 });
 ```
 
@@ -44,35 +44,36 @@ createStackNavigator({
 
 Options for the router:
 
-- `initialRouteName` - Sets the default screen of the stack. Must match one of the keys in route configs.
-- `initialRouteParams` - The params for the initial route
-- `initialRouteKey` - Optional identifier of the initial route
-- `navigationOptions` - Default navigation options to use for screens
-- `paths` - A mapping of overrides for the paths set in the route configs
+* `initialRouteName` - Sets the default screen of the stack. Must match one of the keys in route configs.
+* `initialRouteParams` - The params for the initial route
+* `initialRouteKey` - Optional identifier of the initial route
+* `navigationOptions` - Default navigation options to use for screens
+* `paths` - A mapping of overrides for the paths set in the route configs
 
 Visual options:
 
-- `mode` - Defines the style for rendering and transitions:
-  - `card` - Use the standard iOS and Android screen transitions. This is the default.
-  - `modal` - Make the screens slide in from the bottom which is a common iOS pattern. Only works on iOS, has no effect on Android.
-- `headerMode` - Specifies how the header should be rendered:
-  - `float` - Render a single header that stays at the top and animates as screens are changed. This is a common pattern on iOS.
-  - `screen` - Each screen has a header attached to it and the header fades in and out together with the screen. This is a common pattern on Android.
-  - `none` - No header will be rendered.
-- `headerBackTitleVisible` - A reasonable default is supplied for whether the back button title should be visible or not, but if you want to override that you can use `true` or `false` in this option.
-- `headerTransitionPreset` - Specifies how the header should transition from one screen to another when `headerMode: float` is enabled.
-  - `fade-in-place` - Header components cross-fade without moving, similar to the Twitter, Instagram, and Facebook app for iOS. This is the default value.
-  - `uikit` - An approximation of the default behavior for iOS.
-- `headerLayoutPreset` - Specifies how to lay out the header components.
-  - `left` - Anchor the title to the left, near the back button or other left component. This is the default on Android. When used on iOS, the header back title is hidden. Content from the left component will overflow underneath the title, if you need to adjust this you can use `headerLeftContainerStyle` and `headerTitleContainerStyle`. Additionally, this alignment is incompatible with `headerTransitionPreset: 'uikit'`.
-  - `center` - Center the title, this is the default on iOS.
-- `cardStyle` - Use this prop to override or extend the default style for an individual card in stack.
-- `transitionConfig` - Function to return an object that is merged with the default screen transitions (take a look at TransitionConfig in [type definitions](https://github.com/react-navigation/react-navigation/blob/master/flow/react-navigation.js)). Provided function will be passed the following arguments:
-  - `transitionProps` - Transition props for the new screen.
-  - `prevTransitionProps` - Transitions props for the old screen.
-  - `isModal` - Boolean specifying if screen is modal.
-- `onTransitionStart` - Function to be invoked when the card transition animation is about to start.
-- `onTransitionEnd` - Function to be invoked once the card transition animation completes.
+* `mode` - Defines the style for rendering and transitions:
+  * `card` - Use the standard iOS and Android screen transitions. This is the default.
+  * `modal` - Make the screens slide in from the bottom which is a common iOS pattern. Only works on iOS, has no effect on Android.
+* `headerMode` - Specifies how the header should be rendered:
+  * `float` - Render a single header that stays at the top and animates as screens are changed. This is a common pattern on iOS.
+  * `screen` - Each screen has a header attached to it and the header fades in and out together with the screen. This is a common pattern on Android.
+  * `none` - No header will be rendered.
+* `headerBackTitleVisible` - A reasonable default is supplied for whether the back button title should be visible or not, but if you want to override that you can use `true` or `false` in this option.
+* `headerTransitionPreset` - Specifies how the header should transition from one screen to another when `headerMode: float` is enabled.
+  * `fade-in-place` - Header components cross-fade without moving, similar to the Twitter, Instagram, and Facebook app for iOS. This is the default value.
+  * `uikit` - An approximation of the default behavior for iOS.
+* `headerLayoutPreset` - Specifies how to lay out the header components.
+  * `left` - Anchor the title to the left, near the back button or other left component. This is the default on Android. When used on iOS, the header back title is hidden. Content from the left component will overflow underneath the title, if you need to adjust this you can use `headerLeftContainerStyle` and `headerTitleContainerStyle`. Additionally, this alignment is incompatible with `headerTransitionPreset: 'uikit'`.
+  * `center` - Center the title, this is the default on iOS.
+* `cardStyle` - Use this prop to override or extend the default style for an individual card in stack.
+* `transitionConfig` - Function to return an object that is merged with the default screen transitions (take a look at TransitionConfig in [type definitions](
+https://github.com/react-navigation/react-navigation/blob/master/flow/react-navigation.js)). Provided function will be passed the following arguments: 
+  * `transitionProps` - Transition props for the new screen. 
+  * `prevTransitionProps` - Transitions props for the old screen. 
+  * `isModal` - Boolean specifying if screen is modal.
+* `onTransitionStart` - Function to be invoked when the card transition animation is about to start.
+* `onTransitionEnd` - Function to be invoked once the card transition animation completes.
 
 ### `navigationOptions` for screens inside of the navigator
 
@@ -107,13 +108,13 @@ StackNavigator({
     navigationOptions: () => ({
       title: `A`,
       headerBackTitle: null
-    })
+    }),
   },
   B: {
     screen: BScreen,
     navigationOptions: () => ({
-      title: `B`
-    })
+      title: `B`,
+    }),
   }
 });
 ```
@@ -128,15 +129,15 @@ StackNavigator({
     screen: AScreen,
     navigationOptions: () => ({
       title: `A`,
-      headerBackTitle: "A much too long text for back button from B to A",
+      headerBackTitle: 'A much too long text for back button from B to A',
       headerTruncatedBackTitle: `to A`
-    })
+    }),
   },
   B: {
     screen: BScreen,
     navigationOptions: () => ({
-      title: `B`
-    })
+      title: `B`,
+    }),
   }
 });
 ```
@@ -155,7 +156,7 @@ Style object for the header
 
 #### `headerForceInset`
 
-Allows to pass `forceInset` object to internal SafeAreaView used in the header.
+Allows to pass `forceInset` object to internal SafeAreaView used in the header. 
 
 #### `headerTitleStyle`
 
@@ -201,8 +202,8 @@ Whether you can use gestures to dismiss this screen. Defaults to true on iOS, fa
 
 Object to override the distance of touch start from the edge of the screen to recognize gestures. It takes the following properties:
 
-- `horizontal` - _number_ - Distance for horizontal direction. Defaults to 25.
-- `vertical` - _number_ - Distance for vertical direction. Defaults to 135.
+* `horizontal` - _number_ - Distance for horizontal direction. Defaults to 25.
+* `vertical` - _number_ - Distance for vertical direction. Defaults to 135.
 
 #### `gestureDirection`
 
@@ -212,7 +213,8 @@ String to override the direction for dismiss gesture. `default` for normal behav
 
 The navigator component created by `StackNavigator(...)` takes the following props:
 
-- `screenProps` - Pass down extra options to child screens, for example:
+* `screenProps` - Pass down extra options to child screens, for example:
+
 
 ```js
 const SomeStack = createStackNavigator({
@@ -236,19 +238,19 @@ You can view these examples directly on your phone by visiting [our expo demo](h
 const ModalNavigator = createStackNavigator(
   {
     Main: { screen: Main },
-    Login: { screen: Login }
+    Login: { screen: Login },
   },
   {
-    headerMode: "none",
-    mode: "modal",
+    headerMode: 'none',
+    mode: 'modal',
     navigationOptions: {
-      gesturesEnabled: false
+      gesturesEnabled: false,
     },
     transitionConfig: () => ({
       transitionSpec: {
         duration: 300,
         easing: Easing.out(Easing.poly(4)),
-        timing: Animated.timing
+        timing: Animated.timing,
       },
       screenInterpolator: sceneProps => {
         const { layout, position, scene } = sceneProps;
@@ -257,17 +259,17 @@ const ModalNavigator = createStackNavigator(
         const height = layout.initHeight;
         const translateY = position.interpolate({
           inputRange: [index - 1, index, index + 1],
-          outputRange: [height, 0, 0]
+          outputRange: [height, 0, 0],
         });
 
         const opacity = position.interpolate({
           inputRange: [index - 1, index - 0.99, index],
-          outputRange: [0, 1, 1]
+          outputRange: [0, 1, 1],
         });
 
         return { opacity, transform: [{ translateY }] };
-      }
-    })
+      },
+    }),
   }
 );
 ```
@@ -279,10 +281,10 @@ Header transitions can also be configured using `headerLeftInterpolator`, `heade
 We can’t set the `StackNavigatorConfig`’s `mode` dynamically. Instead we are going to use a custom `transitionConfig` to render the specfific transition we want - modal or card - on a screen by screen basis.
 
 ```js
-import { createStackNavigator, StackViewTransitionConfigs } from "react-navigation";
+import { createStackNavigator, StackViewTransitionConfigs } from 'react-navigation';
 
 /* The screens you add to IOS_MODAL_ROUTES will have the modal transition.  */
-const IOS_MODAL_ROUTES = ["OptionsScreen"];
+const IOS_MODAL_ROUTES = ['OptionsScreen'];
 
 let dynamicModalTransition = (transitionProps, prevTransitionProps) => {
   return StackViewTransitionConfigs.defaultTransitionConfig(
@@ -298,6 +300,6 @@ let dynamicModalTransition = (transitionProps, prevTransitionProps) => {
 
 const HomeStack = createStackNavigator(
   { DetailScreen, HomeScreen, OptionsScreen },
-  { initialRouteName: "HomeScreen", transitionConfig: dynamicModalTransition }
+  { initialRouteName: 'HomeScreen', transitionConfig: dynamicModalTransition }
 );
 ```

--- a/docs/stack-navigator.md
+++ b/docs/stack-navigator.md
@@ -27,16 +27,16 @@ createStackNavigator({
     // When `ProfileScreen` is loaded by the StackNavigator, it will be given a `navigation` prop.
 
     // Optional: When deep linking or using react-navigation in a web app, this path is used:
-    path: 'people/:name',
+    path: "people/:name",
     // The action and route params are extracted from the path.
 
     // Optional: Override the `navigationOptions` for the screen
     navigationOptions: ({ navigation }) => ({
-      title: `${navigation.state.params.name}'s Profile'`,
-    }),
+      title: `${navigation.state.params.name}'s Profile'`
+    })
   },
 
-  ...MyOtherRoutes,
+  ...MyOtherRoutes
 });
 ```
 
@@ -44,36 +44,35 @@ createStackNavigator({
 
 Options for the router:
 
-* `initialRouteName` - Sets the default screen of the stack. Must match one of the keys in route configs.
-* `initialRouteParams` - The params for the initial route
-* `initialRouteKey` - Optional identifier of the initial route
-* `navigationOptions` - Default navigation options to use for screens
-* `paths` - A mapping of overrides for the paths set in the route configs
+- `initialRouteName` - Sets the default screen of the stack. Must match one of the keys in route configs.
+- `initialRouteParams` - The params for the initial route
+- `initialRouteKey` - Optional identifier of the initial route
+- `navigationOptions` - Default navigation options to use for screens
+- `paths` - A mapping of overrides for the paths set in the route configs
 
 Visual options:
 
-* `mode` - Defines the style for rendering and transitions:
-  * `card` - Use the standard iOS and Android screen transitions. This is the default.
-  * `modal` - Make the screens slide in from the bottom which is a common iOS pattern. Only works on iOS, has no effect on Android.
-* `headerMode` - Specifies how the header should be rendered:
-  * `float` - Render a single header that stays at the top and animates as screens are changed. This is a common pattern on iOS.
-  * `screen` - Each screen has a header attached to it and the header fades in and out together with the screen. This is a common pattern on Android.
-  * `none` - No header will be rendered.
-* `headerBackTitleVisible` - A reasonable default is supplied for whether the back button title should be visible or not, but if you want to override that you can use `true` or `false` in this option.
-* `headerTransitionPreset` - Specifies how the header should transition from one screen to another when `headerMode: float` is enabled.
-  * `fade-in-place` - Header components cross-fade without moving, similar to the Twitter, Instagram, and Facebook app for iOS. This is the default value.
-  * `uikit` - An approximation of the default behavior for iOS.
-* `headerLayoutPreset` - Specifies how to lay out the header components.
-  * `left` - Anchor the title to the left, near the back button or other left component. This is the default on Android. When used on iOS, the header back title is hidden. Content from the left component will overflow underneath the title, if you need to adjust this you can use `headerLeftContainerStyle` and `headerTitleContainerStyle`. Additionally, this alignment is incompatible with `headerTransitionPreset: 'uikit'`.
-  * `center` - Center the title, this is the default on iOS.
-* `cardStyle` - Use this prop to override or extend the default style for an individual card in stack.
-* `transitionConfig` - Function to return an object that is merged with the default screen transitions (take a look at TransitionConfig in [type definitions](
-https://github.com/react-navigation/react-navigation/blob/master/flow/react-navigation.js)). Provided function will be passed the following arguments: 
-  * `transitionProps` - Transition props for the new screen. 
-  * `prevTransitionProps` - Transitions props for the old screen. 
-  * `isModal` - Boolean specifying if screen is modal.
-* `onTransitionStart` - Function to be invoked when the card transition animation is about to start.
-* `onTransitionEnd` - Function to be invoked once the card transition animation completes.
+- `mode` - Defines the style for rendering and transitions:
+  - `card` - Use the standard iOS and Android screen transitions. This is the default.
+  - `modal` - Make the screens slide in from the bottom which is a common iOS pattern. Only works on iOS, has no effect on Android.
+- `headerMode` - Specifies how the header should be rendered:
+  - `float` - Render a single header that stays at the top and animates as screens are changed. This is a common pattern on iOS.
+  - `screen` - Each screen has a header attached to it and the header fades in and out together with the screen. This is a common pattern on Android.
+  - `none` - No header will be rendered.
+- `headerBackTitleVisible` - A reasonable default is supplied for whether the back button title should be visible or not, but if you want to override that you can use `true` or `false` in this option.
+- `headerTransitionPreset` - Specifies how the header should transition from one screen to another when `headerMode: float` is enabled.
+  - `fade-in-place` - Header components cross-fade without moving, similar to the Twitter, Instagram, and Facebook app for iOS. This is the default value.
+  - `uikit` - An approximation of the default behavior for iOS.
+- `headerLayoutPreset` - Specifies how to lay out the header components.
+  - `left` - Anchor the title to the left, near the back button or other left component. This is the default on Android. When used on iOS, the header back title is hidden. Content from the left component will overflow underneath the title, if you need to adjust this you can use `headerLeftContainerStyle` and `headerTitleContainerStyle`. Additionally, this alignment is incompatible with `headerTransitionPreset: 'uikit'`.
+  - `center` - Center the title, this is the default on iOS.
+- `cardStyle` - Use this prop to override or extend the default style for an individual card in stack.
+- `transitionConfig` - Function to return an object that is merged with the default screen transitions (take a look at TransitionConfig in [type definitions](https://github.com/react-navigation/react-navigation/blob/master/flow/react-navigation.js)). Provided function will be passed the following arguments:
+  - `transitionProps` - Transition props for the new screen.
+  - `prevTransitionProps` - Transitions props for the old screen.
+  - `isModal` - Boolean specifying if screen is modal.
+- `onTransitionStart` - Function to be invoked when the card transition animation is about to start.
+- `onTransitionEnd` - Function to be invoked once the card transition animation completes.
 
 ### `navigationOptions` for screens inside of the navigator
 
@@ -108,13 +107,13 @@ StackNavigator({
     navigationOptions: () => ({
       title: `A`,
       headerBackTitle: null
-    }),
+    })
   },
   B: {
     screen: BScreen,
     navigationOptions: () => ({
-      title: `B`,
-    }),
+      title: `B`
+    })
   }
 });
 ```
@@ -129,15 +128,15 @@ StackNavigator({
     screen: AScreen,
     navigationOptions: () => ({
       title: `A`,
-      headerBackTitle: 'A much too long text for back button from B to A',
+      headerBackTitle: "A much too long text for back button from B to A",
       headerTruncatedBackTitle: `to A`
-    }),
+    })
   },
   B: {
     screen: BScreen,
     navigationOptions: () => ({
-      title: `B`,
-    }),
+      title: `B`
+    })
   }
 });
 ```
@@ -156,7 +155,7 @@ Style object for the header
 
 #### `headerForceInset`
 
-Allows to pass `forceInset` object to internal SafeAreaView used in the header. 
+Allows to pass `forceInset` object to internal SafeAreaView used in the header.
 
 #### `headerTitleStyle`
 
@@ -202,8 +201,8 @@ Whether you can use gestures to dismiss this screen. Defaults to true on iOS, fa
 
 Object to override the distance of touch start from the edge of the screen to recognize gestures. It takes the following properties:
 
-* `horizontal` - _number_ - Distance for horizontal direction. Defaults to 25.
-* `vertical` - _number_ - Distance for vertical direction. Defaults to 135.
+- `horizontal` - _number_ - Distance for horizontal direction. Defaults to 25.
+- `vertical` - _number_ - Distance for vertical direction. Defaults to 135.
 
 #### `gestureDirection`
 
@@ -213,8 +212,7 @@ String to override the direction for dismiss gesture. `default` for normal behav
 
 The navigator component created by `StackNavigator(...)` takes the following props:
 
-* `screenProps` - Pass down extra options to child screens, for example:
-
+- `screenProps` - Pass down extra options to child screens, for example:
 
 ```js
 const SomeStack = createStackNavigator({
@@ -238,19 +236,19 @@ You can view these examples directly on your phone by visiting [our expo demo](h
 const ModalNavigator = createStackNavigator(
   {
     Main: { screen: Main },
-    Login: { screen: Login },
+    Login: { screen: Login }
   },
   {
-    headerMode: 'none',
-    mode: 'modal',
+    headerMode: "none",
+    mode: "modal",
     navigationOptions: {
-      gesturesEnabled: false,
+      gesturesEnabled: false
     },
     transitionConfig: () => ({
       transitionSpec: {
         duration: 300,
         easing: Easing.out(Easing.poly(4)),
-        timing: Animated.timing,
+        timing: Animated.timing
       },
       screenInterpolator: sceneProps => {
         const { layout, position, scene } = sceneProps;
@@ -259,19 +257,47 @@ const ModalNavigator = createStackNavigator(
         const height = layout.initHeight;
         const translateY = position.interpolate({
           inputRange: [index - 1, index, index + 1],
-          outputRange: [height, 0, 0],
+          outputRange: [height, 0, 0]
         });
 
         const opacity = position.interpolate({
           inputRange: [index - 1, index - 0.99, index],
-          outputRange: [0, 1, 1],
+          outputRange: [0, 1, 1]
         });
 
         return { opacity, transform: [{ translateY }] };
-      },
-    }),
+      }
+    })
   }
 );
 ```
 
 Header transitions can also be configured using `headerLeftInterpolator`, `headerTitleInterpolator` and `headerRightInterpolator` fields under `transitionConfig`.
+
+#### Specifying the transition mode for a stack's screens explicitly
+
+We can’t set the `StackNavigatorConfig`’s `mode` dynamically. Instead we are going to use a custom `transitionConfig` to render the specfific transition we want - modal or card - on a screen by screen basis.
+
+```js
+import { createStackNavigator, StackViewTransitionConfigs } from "react-navigation";
+
+/* The screens you add to IOS_MODAL_ROUTES will have the modal transition.  */
+const IOS_MODAL_ROUTES = ["OptionsScreen"];
+
+let dynamicModalTransition = (transitionProps, prevTransitionProps) => {
+  return StackViewTransitionConfigs.defaultTransitionConfig(
+    transitionProps,
+    prevTransitionProps,
+    IOS_MODAL_ROUTES.some(
+      screenName =>
+        screenName === transitionProps.scene.route.routeName ||
+        (prevTransitionProps && screenName === prevTransitionProps.scene.route.routeName)
+    )
+  );
+};
+
+const HomeStack = createStackNavigator(
+  { DetailScreen, HomeScreen, OptionsScreen },
+  { initialRouteName: "HomeScreen", transitionConfig: dynamicModalTransition }
+);
+```


### PR DESCRIPTION
Add entry to the navigation options resolution on how to dynamically set the `mode` property for a stack navigator. This is useful if you have a stack with more than one screen and want to have the `modal` transition on iOS on some screens, but the `card` transition on others.