### PR TITLE
Add reminder to include super(props)

### DIFF
--- a/docs/with-navigation.md
+++ b/docs/with-navigation.md
@@ -16,6 +16,10 @@ import { Button } from 'react-native';
 import { withNavigation } from 'react-navigation';
 
 class MyBackButton extends React.Component {
+  constructor(props) {
+    super(props)
+  }
+
   render() {
     return <Button title="Back" onPress={() => { this.props.navigation.goBack() }} />;
   }
@@ -37,3 +41,5 @@ export default withNavigation(MyBackButton);
 // MyNavBar.ts
 <MyBackButton onRef={(elem) => this.backButton = elem} />
 ```
+
+- Don't forget to include Props in your class constructor, otherwise `this.props.navigation` will be `undefined`. 


### PR DESCRIPTION
The example doesn't include this dependency and people will have to remember to add it on their own. It would be useful to have a fully working Button class in the example. I pasted the example, forgot to add the constructor function on my first go around and only remembered to add it in after getting the error again.