### PR TITLE
Cross linking back to guides

### DIFF
--- a/docs/bottom-tab-navigator.md
+++ b/docs/bottom-tab-navigator.md
@@ -6,6 +6,8 @@ sidebar_label: createBottomTabNavigator
 
 A simple tab bar on the bottom of the screen that lets you switch between different routes. Routes are lazily initialized -- their screen components are not mounted until they are first focused.
 
+> For a complete usage guide please visit [Tab Navigation](https://reactnavigation.org/docs/en/tab-based-navigation.html)
+
 ```js
 createBottomTabNavigator(RouteConfigs, BottomTabNavigatorConfig);
 ```


### PR DESCRIPTION
While looking up a way to style the createBottomTabNavigator while being exported in React-Native I came across the API Reference page first.  The examples we're a bit confusing before discovering the guides as well.  I think it would be great if some cross linking could be implemented to further help those who may stumble across the API references first before seeing the guides.  Would save a lot of time and further improve some already awesome documentation for React-Navigation.