### PR TITLE
Fix Stack name on v1 documentation

### DIFF
--- a/website/versioned_docs/version-1.x/headers.md
+++ b/website/versioned_docs/version-1.x/headers.md
@@ -146,7 +146,7 @@ const RootStack = StackNavigator(
 ```
 <a href="https://snack.expo.io/@react-navigation/sharing-header-styles" target="blank" class="run-code-button">&rarr; Run this code</a>
 
-Now, any screen that belongs to the `RouteStack` will have our wonderful branded styles. Surely though, there must be a way to override these options if we need to?
+Now, any screen that belongs to the `RootStack` will have our wonderful branded styles. Surely though, there must be a way to override these options if we need to?
 
 ## Overriding shared `navigationOptions`
 


### PR DESCRIPTION
Documentation was referring to an unexisting `RouteStack`, when `RootStack` should've been used instead