### PR TITLE
add complete installation instructions for Android

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,6 +38,37 @@ Link all native dependencies:
 react-native link
 ```
 
+No additional steps are required for iOS.
+
+To finalise installation of react-native-gesture-handler for Android, be sure to make the necessary modifications to `MainActivity.java`:
+
+```diff
+package com.swmansion.gesturehandler.react.example;
+
+import com.facebook.react.ReactActivity;
++ import com.facebook.react.ReactActivityDelegate;
++ import com.facebook.react.ReactRootView;
++ import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
+
+public class MainActivity extends ReactActivity {
+
+  @Override
+  protected String getMainComponentName() {
+    return "Example";
+  }
+
++  @Override
++  protected ReactActivityDelegate createReactActivityDelegate() {
++    return new ReactActivityDelegate(this, getMainComponentName()) {
++      @Override
++      protected ReactRootView createRootView() {
++       return new RNGestureHandlerEnabledRootView(MainActivity.this);
++      }
++    };
++  }
+}
+```
+
 ## Hybrid iOS Applications (Skip for RN only projects)
 
 If you're using React Navigation within a hybrid app - an iOS app that has both Swift/ObjC and React Native parts - you may be missing the `RCTLinkingIOS` subspec in your Podfile, which is installed by default in new RN projects. To add this, ensure your Podfile looks like the following:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,7 +43,7 @@ No additional steps are required for iOS.
 To finalise installation of react-native-gesture-handler for Android, be sure to make the necessary modifications to `MainActivity.java`:
 
 ```diff
-package com.swmansion.gesturehandler.react.example;
+package com.reactnavigation.example;
 
 import com.facebook.react.ReactActivity;
 + import com.facebook.react.ReactActivityDelegate;


### PR DESCRIPTION
Now that react-native-gesture-handler needs to be installed manually, the documentation should be complete and specific on how to do this. Seems to have tripped a few people up here: https://github.com/react-navigation/react-navigation/issues/5251