### PR TITLE
Add specificity to `react-native link`

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,7 +35,7 @@ yarn add react-native-gesture-handler
 Link all native dependencies:
 
 ```bash
-react-native link
+react-native link react-native-gesture-handler
 ```
 
 No additional steps are required for iOS.

--- a/website/versioned_docs/version-3.x/getting-started.md
+++ b/website/versioned_docs/version-3.x/getting-started.md
@@ -36,7 +36,7 @@ yarn add react-native-gesture-handler
 Link all native dependencies:
 
 ```bash
-react-native link
+react-native link react-native-gesture-handler
 ```
 
 No additional steps are required for iOS.


### PR DESCRIPTION
### Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `website/versioned_docs/version-3.x/file-you-edited.md` for version 3. :+1:
