### PR TITLE
Update code samples in Stack Navigator docs to correctly use defaultNavigationOptions in navigator config

### DIFF
--- a/docs/stack-navigator.md
+++ b/docs/stack-navigator.md
@@ -261,7 +261,7 @@ const ModalNavigator = createStackNavigator(
   {
     headerMode: 'none',
     mode: 'modal',
-    navigationOptions: {
+    defaultNavigationOptions: {
       gesturesEnabled: false,
     },
     transitionConfig: () => ({

--- a/website/versioned_docs/version-3.x/stack-navigator.md
+++ b/website/versioned_docs/version-3.x/stack-navigator.md
@@ -71,9 +71,9 @@ Visual options:
 * `cardShadowEnabled` - Use this prop to have visible shadows during transitions. Defaults to `true`
 * `cardOverlayEnabled` - Use this prop to have visible stack card overlays during transitions. Defaults to `false`.
 * `transitionConfig` - Function to return an object that is merged with the default screen transitions (take a look at TransitionConfig in [type definitions](
-https://github.com/react-navigation/react-navigation/blob/master/flow/react-navigation.js)). Provided function will be passed the following arguments: 
-  * `transitionProps` - Transition props for the new screen. 
-  * `prevTransitionProps` - Transitions props for the old screen. 
+https://github.com/react-navigation/react-navigation/blob/master/flow/react-navigation.js)). Provided function will be passed the following arguments:
+  * `transitionProps` - Transition props for the new screen.
+  * `prevTransitionProps` - Transitions props for the old screen.
   * `isModal` - Boolean specifying if screen is modal.
 * `onTransitionStart` - Function to be invoked when the card transition animation is about to start.
 * `onTransitionEnd` - Function to be invoked once the card transition animation completes.
@@ -160,7 +160,7 @@ Style object for the header
 
 #### `headerForceInset`
 
-Allows to pass `forceInset` object to internal SafeAreaView used in the header. 
+Allows to pass `forceInset` object to internal SafeAreaView used in the header.
 
 #### `headerTitleStyle`
 
@@ -262,7 +262,7 @@ const ModalNavigator = createStackNavigator(
   {
     headerMode: 'none',
     mode: 'modal',
-    navigationOptions: {
+    defaultNavigationOptions: {
       gesturesEnabled: false,
     },
     transitionConfig: () => ({


### PR DESCRIPTION
Noticed the docs show code samples using `navigationOptions` instead of `defaultNavigationOptions` in config object for `createStackNavigator`.