### PR TITLE
Update NavigationService example for v3

### DIFF
--- a/website/versioned_docs/version-3.x/navigating-without-navigation-prop.md
+++ b/website/versioned_docs/version-3.x/navigating-without-navigation-prop.md
@@ -1,7 +1,8 @@
 ---
-id: navigating-without-navigation-prop
+id: version-3.x-navigating-without-navigation-prop
 title: Navigating without the navigation prop
 sidebar_label: Navigating without the navigation prop
+original_id: navigating-without-navigation-prop
 ---
 
 Calling functions such as `navigate` or `popToTop` on the `navigation` prop is not the only way to navigate around your app. As an alternative, you can dispatch navigation actions on your top-level navigator, provided you aren't passing your own `navigation` prop as you would with a redux integration. The presented approach is useful in situations when you want to trigger a navigation action from places where you do not have access to the `navigation` prop, or if you're looking for an alternative to using the `navigation` prop.


### PR DESCRIPTION
I am trying to follow these two doc pages in conjunction:

- https://reactnavigation.org/docs/en/app-containers.html
- https://reactnavigation.org/docs/en/navigating-without-navigation-prop.html

Though the "Navigating without the navigation prop" seems out of date since the introduction of explicit app containers in v3, the **App Containers** page indicates that I can get a ref on the _container_ that functions just like a navigator. After a couple of false starts, I stumbled upon what seems to be the correct setup, but it would have been helpful to start from a working example without having to infer the correct combination.

My minimal working example:

https://snack.expo.io/@brettdh/navigationservice-and-createappcontainer

Possibly related: react-navigation/react-navigation#5252

### Make sure to add your changes to versioned docs

> Thanks for opening a PR!
> 
> The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe single page of the docs (eg. "Getting Started").
> 
> Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `website/versioned_docs/version-3.x/file-you-edited.md` for version 3. :+1:

I didn't see a `website/versioned_docs/version-3.x/navigating-without-navigation-prop.md` file, and I'm not sure if I should be creating one there; please let me know what's correct. Thanks!