### PR TITLE
change null to <React.Fragment /> in header value

### DIFF
--- a/docs/navigation-options-resolution.md
+++ b/docs/navigation-options-resolution.md
@@ -161,7 +161,7 @@ const TabNavigator = createBottomTabNavigator({
 
 TabNavigator.navigationOptions = {
   // Hide the header from AppNavigator stack
-  header: null,
+  header: <React.Fragment />,
 };
 
 const AppNavigator = createStackNavigator({


### PR DESCRIPTION
I think we should assign `<React.Fragment />` instead of `null` once we would like to hide header in navigationOptions.