### PR TITLE
Update v3.x docs stack-navigator.md

### DIFF
--- a/docs/stack-navigator.md
+++ b/docs/stack-navigator.md
@@ -181,6 +181,8 @@ Customize the style for the container of the `headerRight` component, for exampl
 
 Customize the style for the container of the `headerTitle` component, for example to add padding.
 
+By default, `headerTitleContainerStyle` is with an absolute position style and offsets both `left` and `right`. This may lead to white space or overlap between `headerLeft` and `headerTitle` if a customized `headerLeft` is used. It can be solved by adjusting `left` and `right` style in `headerTitleContainerStyle` and `marginHorizontal` in `headerTitleStyle`.
+
 #### `headerTintColor`
 
 Tint color for the header


### PR DESCRIPTION
add some information for white space or overlap between headerLeft and headerTitle.

website/versioned_docs/version-3.x/stack-navigator.md

### Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `website/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
