### PR TITLE
 Adjust deep link set up and usage on Android

### DIFF
--- a/docs/deep-linking.md
+++ b/docs/deep-linking.md
@@ -93,9 +93,7 @@ Next, let's configure our navigation container to extract the path from the app'
 ```js
 const SimpleApp = createAppContainer(createStackNavigator({...}));
 
-// on Android, the URI prefix typically contains a host in addition to scheme
-// on Android, note the required / (slash) at the end of the host property
-const prefix = Platform.OS == 'android' ? 'mychat://mychat/' : 'mychat://';
+const prefix = 'mychat://';
 
 const MainApp = () => <SimpleApp uriPrefix={prefix} />;
 ```
@@ -141,19 +139,26 @@ To test the URI on a real device, open Safari and type `mychat://chat/Eric`.
 
 To configure the external linking in Android, you can create a new intent in the manifest.
 
-In `SimpleApp/android/app/src/main/AndroidManifest.xml`, add the new `intent-filter` inside the `MainActivity` entry with a `VIEW` type action:
+In `SimpleApp/android/app/src/main/AndroidManifest.xml`, do these followings adjustments:
+1. Set `launchMode` of `MainActivity` to `singleTask` in order to receive intent on existing `MainActivity`. It is useful if you want to perform navigation using deep link you have been registered - [details](http://developer.android.com/training/app-indexing/deep-linking.html#adding-filters)
+2. Add the new `intent-filter` inside the `MainActivity` entry with a `VIEW` type action:
 
 ```
-<intent-filter>
-    <action android:name="android.intent.action.MAIN" />
-    <category android:name="android.intent.category.LAUNCHER" />
-</intent-filter>
-<intent-filter>
-    <action android:name="android.intent.action.VIEW" />
-    <category android:name="android.intent.category.DEFAULT" />
-    <category android:name="android.intent.category.BROWSABLE" />
-    <data android:scheme="mychat" android:host="mychat" />            
-</intent-filter>
+<activity
+    android:name=".MainActivity"
+    android:launchMode="singleTask"
+    ...>
+    <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+    </intent-filter>
+    <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="mychat" />            
+    </intent-filter>
+</activity>
 ```
 
 Now, re-install the app:
@@ -165,5 +170,5 @@ react-native run-android
 To test the intent handling in Android, run the following:
 
 ```
-adb shell am start -W -a android.intent.action.VIEW -d "mychat://mychat/chat/Eric" com.simpleapp
+adb shell am start -W -a android.intent.action.VIEW -d "mychat://chat/Eric" com.simpleapp
 ```

--- a/docs/deep-linking.md
+++ b/docs/deep-linking.md
@@ -146,8 +146,7 @@ In `SimpleApp/android/app/src/main/AndroidManifest.xml`, do these followings adj
 ```
 <activity
     android:name=".MainActivity"
-    android:launchMode="singleTask"
-    ...>
+    android:launchMode="singleTask">
     <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />

--- a/website/versioned_docs/version-1.x/deep-linking.md
+++ b/website/versioned_docs/version-1.x/deep-linking.md
@@ -92,9 +92,7 @@ Next, let's configure our navigation container to extract the path from the app'
 ```js
 const SimpleApp = StackNavigator({...}));
 
-// on Android, the URI prefix typically contains a host in addition to scheme
-// on Android, note the required / (slash) at the end of the host property
-const prefix = Platform.OS == 'android' ? 'mychat://mychat/' : 'mychat://';
+const prefix = 'mychat://';
 
 const MainApp = () => <SimpleApp uriPrefix={prefix} />;
 ```
@@ -140,7 +138,9 @@ To test the URI on a real device, open Safari and type `mychat://chat/Eric`.
 
 To configure the external linking in Android, you can create a new intent in the manifest.
 
-In `SimpleApp/android/app/src/main/AndroidManifest.xml`, add the new `VIEW` type `intent-filter` inside the `MainActivity` entry:
+In `SimpleApp/android/app/src/main/AndroidManifest.xml`, do these followings adjustments:
+1. Set `launchMode` of `MainActivity` to `singleTask` in order to receive intent on existing `MainActivity`. It is useful if you want to perform navigation using deep link you have been registered - [details](http://developer.android.com/training/app-indexing/deep-linking.html#adding-filters)
+2. Add the new `intent-filter` inside the `MainActivity` entry with a `VIEW` type action:
 
 ```
 <intent-filter>
@@ -151,7 +151,7 @@ In `SimpleApp/android/app/src/main/AndroidManifest.xml`, add the new `VIEW` type
     <action android:name="android.intent.action.VIEW" />
     <category android:name="android.intent.category.DEFAULT" />
     <category android:name="android.intent.category.BROWSABLE" />
-    <data android:scheme="mychat" android:host="mychat" />            
+    <data android:scheme="mychat" />            
 </intent-filter>
 ```
 
@@ -164,5 +164,5 @@ react-native run-android
 To test the intent handling in Android, run the following:
 
 ```
-adb shell am start -W -a android.intent.action.VIEW -d "mychat://mychat/chat/Eric" com.simpleapp
+adb shell am start -W -a android.intent.action.VIEW -d "mychat://chat/Eric" com.simpleapp
 ```

--- a/website/versioned_docs/version-1.x/deep-linking.md
+++ b/website/versioned_docs/version-1.x/deep-linking.md
@@ -143,16 +143,20 @@ In `SimpleApp/android/app/src/main/AndroidManifest.xml`, do these followings adj
 2. Add the new `intent-filter` inside the `MainActivity` entry with a `VIEW` type action:
 
 ```
-<intent-filter>
-    <action android:name="android.intent.action.MAIN" />
-    <category android:name="android.intent.category.LAUNCHER" />
-</intent-filter>
-<intent-filter>
-    <action android:name="android.intent.action.VIEW" />
-    <category android:name="android.intent.category.DEFAULT" />
-    <category android:name="android.intent.category.BROWSABLE" />
-    <data android:scheme="mychat" />            
-</intent-filter>
+<activity
+    android:name=".MainActivity"
+    android:launchMode="singleTask">
+    <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+    </intent-filter>
+    <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="mychat" />            
+    </intent-filter>
+</activity>
 ```
 
 Now, re-install the app:

--- a/website/versioned_docs/version-2.x/deep-linking.md
+++ b/website/versioned_docs/version-2.x/deep-linking.md
@@ -92,9 +92,7 @@ Next, let's configure our navigation container to extract the path from the app'
 ```js
 const SimpleApp = createStackNavigator({...});
 
-// on Android, the URI prefix typically contains a host in addition to scheme
-// on Android, note the required / (slash) at the end of the host property
-const prefix = Platform.OS == 'android' ? 'mychat://mychat/' : 'mychat://';
+const prefix = 'mychat://';
 
 const MainApp = () => <SimpleApp uriPrefix={prefix} />;
 ```
@@ -140,7 +138,9 @@ To test the URI on a real device, open Safari and type `mychat://chat/Eric`.
 
 To configure the external linking in Android, you can create a new intent in the manifest.
 
-In `SimpleApp/android/app/src/main/AndroidManifest.xml`, add the new `intent-filter` inside the `MainActivity` entry with a `VIEW` type action:
+In `SimpleApp/android/app/src/main/AndroidManifest.xml`, do these followings adjustments:
+1. Set `launchMode` of `MainActivity` to `singleTask` in order to receive intent on existing `MainActivity`. It is useful if you want to perform navigation using deep link you have been registered - [details](http://developer.android.com/training/app-indexing/deep-linking.html#adding-filters)
+2. Add the new `intent-filter` inside the `MainActivity` entry with a `VIEW` type action:
 
 ```
 <intent-filter>
@@ -151,7 +151,7 @@ In `SimpleApp/android/app/src/main/AndroidManifest.xml`, add the new `intent-fil
     <action android:name="android.intent.action.VIEW" />
     <category android:name="android.intent.category.DEFAULT" />
     <category android:name="android.intent.category.BROWSABLE" />
-    <data android:scheme="mychat" android:host="mychat" />            
+    <data android:scheme="mychat" />            
 </intent-filter>
 ```
 
@@ -164,5 +164,5 @@ react-native run-android
 To test the intent handling in Android, run the following:
 
 ```
-adb shell am start -W -a android.intent.action.VIEW -d "mychat://mychat/chat/Eric" com.simpleapp
+adb shell am start -W -a android.intent.action.VIEW -d "mychat://chat/Eric" com.simpleapp
 ```

--- a/website/versioned_docs/version-2.x/deep-linking.md
+++ b/website/versioned_docs/version-2.x/deep-linking.md
@@ -143,16 +143,20 @@ In `SimpleApp/android/app/src/main/AndroidManifest.xml`, do these followings adj
 2. Add the new `intent-filter` inside the `MainActivity` entry with a `VIEW` type action:
 
 ```
-<intent-filter>
-    <action android:name="android.intent.action.MAIN" />
-    <category android:name="android.intent.category.LAUNCHER" />
-</intent-filter>
-<intent-filter>
-    <action android:name="android.intent.action.VIEW" />
-    <category android:name="android.intent.category.DEFAULT" />
-    <category android:name="android.intent.category.BROWSABLE" />
-    <data android:scheme="mychat" />            
-</intent-filter>
+<activity
+    android:name=".MainActivity"
+    android:launchMode="singleTask">
+    <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+    </intent-filter>
+    <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="mychat" />            
+    </intent-filter>
+</activity>
 ```
 
 Now, re-install the app:

--- a/website/versioned_docs/version-3.x/deep-linking.md
+++ b/website/versioned_docs/version-3.x/deep-linking.md
@@ -92,9 +92,7 @@ Next, let's configure our navigation container to extract the path from the app'
 ```js
 const SimpleApp = createAppContainer(createStackNavigator({...}));
 
-// on Android, the URI prefix typically contains a host in addition to scheme
-// on Android, note the required / (slash) at the end of the host property
-const prefix = Platform.OS == 'android' ? 'mychat://mychat/' : 'mychat://';
+const prefix = 'mychat://';
 
 const MainApp = () => <SimpleApp uriPrefix={prefix} />;
 ```
@@ -140,7 +138,9 @@ To test the URI on a real device, open Safari and type `mychat://chat/Eric`.
 
 To configure the external linking in Android, you can create a new intent in the manifest.
 
-In `SimpleApp/android/app/src/main/AndroidManifest.xml`, add the new `intent-filter` inside the `MainActivity` entry with a `VIEW` type action:
+In `SimpleApp/android/app/src/main/AndroidManifest.xml`, do these followings adjustments:
+1. Set `launchMode` of `MainActivity` to `singleTask` in order to receive intent on existing `MainActivity`. It is useful if you want to perform navigation using deep link you have been registered - [details](http://developer.android.com/training/app-indexing/deep-linking.html#adding-filters)
+2. Add the new `intent-filter` inside the `MainActivity` entry with a `VIEW` type action:
 
 ```
 <intent-filter>
@@ -151,7 +151,7 @@ In `SimpleApp/android/app/src/main/AndroidManifest.xml`, add the new `intent-fil
     <action android:name="android.intent.action.VIEW" />
     <category android:name="android.intent.category.DEFAULT" />
     <category android:name="android.intent.category.BROWSABLE" />
-    <data android:scheme="mychat" android:host="mychat" />            
+    <data android:scheme="mychat" />            
 </intent-filter>
 ```
 
@@ -164,5 +164,5 @@ react-native run-android
 To test the intent handling in Android, run the following:
 
 ```
-adb shell am start -W -a android.intent.action.VIEW -d "mychat://mychat/chat/Eric" com.simpleapp
+adb shell am start -W -a android.intent.action.VIEW -d "mychat://chat/Eric" com.simpleapp
 ```

--- a/website/versioned_docs/version-3.x/deep-linking.md
+++ b/website/versioned_docs/version-3.x/deep-linking.md
@@ -143,16 +143,20 @@ In `SimpleApp/android/app/src/main/AndroidManifest.xml`, do these followings adj
 2. Add the new `intent-filter` inside the `MainActivity` entry with a `VIEW` type action:
 
 ```
-<intent-filter>
-    <action android:name="android.intent.action.MAIN" />
-    <category android:name="android.intent.category.LAUNCHER" />
-</intent-filter>
-<intent-filter>
-    <action android:name="android.intent.action.VIEW" />
-    <category android:name="android.intent.category.DEFAULT" />
-    <category android:name="android.intent.category.BROWSABLE" />
-    <data android:scheme="mychat" />            
-</intent-filter>
+<activity
+    android:name=".MainActivity"
+    android:launchMode="singleTask">
+    <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+    </intent-filter>
+    <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="mychat" />            
+    </intent-filter>
+</activity>
 ```
 
 Now, re-install the app:


### PR DESCRIPTION
This PR adjust deep link set up on Android so the prefix will be the same with iOS.
I also add `android:launchMode` on set up instruction in order to support deep link navigation when the app is running.