### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,7 +40,9 @@ react-native link react-native-gesture-handler
 
 No additional steps are required for iOS.
 
-To finalise installation of react-native-gesture-handler for Android, be sure to make the necessary modifications to `MainActivity.java`:
+Gesture Handler is already [part of Expo](https://kmagiera.github.io/react-native-gesture-handler/docs/getting-started.html#with-expo-https-expoio) and there is no extra configuration of react-native-gesture-handler is required.
+
+If you are not using Expo you have will to finalise the installation of react-native-gesture-handler for Android, by manually making the necessary modifications to `MainActivity.java`:
 
 ```diff
 package com.reactnavigation.example;


### PR DESCRIPTION
Expand the Getting Started  (version-3.x) notes, to specifiy that there is no need or way for users of Expo to modify the `MainActivity.java` file, with provided reference link.

### Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `website/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
