### PR TITLE
fix function-after-focusing-screen.md

### DIFF
--- a/docs/function-after-focusing-screen.md
+++ b/docs/function-after-focusing-screen.md
@@ -1,8 +1,7 @@
 ---
-id: version-3.x-function-after-focusing-screen
+id: function-after-focusing-screen
 title: Call a function when focused screen changes
 sidebar_label: Call a function when focused screen changes
-original_id: function-after-focusing-screen
 ---
 
 In this guide we will call a function on screen focusing. This is useful for making additional API calls when a user revisits a particular screen in a Tab Navigator, or to track user events as they tap around our app.

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -42,7 +42,7 @@
     "Drawer navigation": "Drawer navigation",
     "drawer-navigator": "createDrawerNavigator",
     "createDrawerNavigator": "createDrawerNavigator",
-    "version-3.x-function-after-focusing-screen": "Call a function when focused screen changes",
+    "function-after-focusing-screen": "Call a function when focused screen changes",
     "Call a function when focused screen changes": "Call a function when focused screen changes",
     "getting-started": "Getting started",
     "Getting started": "Getting started",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -30,7 +30,8 @@
       "screen-tracking",
       "state-persistence",
       "redux-integration",
-      "web-support"
+      "web-support",
+      "function-after-focusing-screen"
     ],
     "Build your own Navigator": [
       "custom-navigator-overview",


### PR DESCRIPTION
this fixes the fact that "Call a function when focused screen changes" is not in the sidebar when you go to the `next` [docs](https://reactnavigation.org/docs/en/next/getting-started.html).