### PR TITLE
Make first code example more intuitively clear

### DIFF
--- a/docs/connecting-navigation-prop.md
+++ b/docs/connecting-navigation-prop.md
@@ -9,7 +9,6 @@ sidebar_label: Access the navigation prop from any component
 ```javascript
 import React from 'react';
 import { Button } from 'react-native';
-import { withNavigation } from 'react-navigation';
 
 export default class MyBackButton extends React.Component {
   render() {


### PR DESCRIPTION
Line 12 is in my opinion not only confusing but even misleading.

import { withNavigation } from 'react-navigation';

withNavigation is not actually used in the first code section - which intends to demonstrate a failed attempt of using this.props.navigation  in a wrapped component which has no access to it - 

Moreover, it might even lead the reader to believe that the import of withNavigation might suffice on it's own to allow the use of props.navigation

My apologies if this is totally off, but it seems like a small readability improvement to me.

### Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `website/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
