### PR TITLE
Routers: fix lix to github source code

### DIFF
--- a/docs/routers.md
+++ b/docs/routers.md
@@ -10,8 +10,8 @@ Routers define a component's navigation state, and they allow the developer to d
 
 `react-navigation` ships with a few standard routers:
 
-- [StackRouter](https://github.com/react-navigation/react-navigation/blob/master/src/routers/StackRouter.js)
-- [TabRouter](https://github.com/react-navigation/react-navigation/blob/master/src/routers/TabRouter.js)
+- [StackRouter](https://github.com/react-navigation/react-navigation-core/blob/master/src/routers/StackRouter.js)
+- [TabRouter](https://github.com/react-navigation/react-navigation-core/blob/master/src/routers/TabRouter.js)
 
 
 ## Using Routers

--- a/website/versioned_docs/version-1.x/routers.md
+++ b/website/versioned_docs/version-1.x/routers.md
@@ -100,7 +100,6 @@ MyStackRouter.router.getStateForAction = (action, state) => {
 Perhaps your app has a unique URI which the built-in routers cannot handle. You can always extend the router `getActionForPathAndParams`.
 
 ```js
-
 import { NavigationActions } from 'react-navigation'
 
 const MyApp = StackNavigator({

--- a/website/versioned_docs/version-2.x/routers.md
+++ b/website/versioned_docs/version-2.x/routers.md
@@ -11,8 +11,8 @@ Routers define a component's navigation state, and they allow the developer to d
 
 `react-navigation` ships with a few standard routers:
 
-- [StackRouter](https://github.com/react-navigation/react-navigation/blob/master/src/routers/StackRouter.js)
-- [TabRouter](https://github.com/react-navigation/react-navigation/blob/master/src/routers/TabRouter.js)
+- [StackRouter](https://github.com/react-navigation/react-navigation/blob/2.x/src/routers/StackRouter.js)
+- [TabRouter](https://github.com/react-navigation/react-navigation/blob/2.x/src/routers/TabRouter.js)
 
 
 ## Using Routers

--- a/website/versioned_docs/version-2.x/routers.md
+++ b/website/versioned_docs/version-2.x/routers.md
@@ -100,7 +100,6 @@ MyStackRouter.router.getStateForAction = (action, state) => {
 Perhaps your app has a unique URI which the built-in routers cannot handle. You can always extend the router `getActionForPathAndParams`.
 
 ```js
-
 import { NavigationActions } from 'react-navigation'
 
 const MyApp = createStackNavigator({

--- a/website/versioned_docs/version-3.x/routers.md
+++ b/website/versioned_docs/version-3.x/routers.md
@@ -100,7 +100,6 @@ MyStackRouter.router.getStateForAction = (action, state) => {
 Perhaps your app has a unique URI which the built-in routers cannot handle. You can always extend the router `getActionForPathAndParams`.
 
 ```js
-
 import { NavigationActions } from 'react-navigation'
 
 const MyApp = createStackNavigator({

--- a/website/versioned_docs/version-3.x/routers.md
+++ b/website/versioned_docs/version-3.x/routers.md
@@ -1,5 +1,5 @@
 ---
-id: version-1.x-routers
+id: version-3.x-routers
 title: Routers
 sidebar_label: Routers
 original_id: routers
@@ -11,8 +11,8 @@ Routers define a component's navigation state, and they allow the developer to d
 
 `react-navigation` ships with a few standard routers:
 
-- [StackRouter](https://github.com/react-navigation/react-navigation/blob/1.x/src/routers/StackRouter.js)
-- [TabRouter](https://github.com/react-navigation/react-navigation/blob/1.x/src/routers/TabRouter.js)
+- [StackRouter](https://github.com/react-navigation/react-navigation-core/blob/master/src/routers/StackRouter.js)
+- [TabRouter](https://github.com/react-navigation/react-navigation-core/blob/master/src/routers/TabRouter.js)
 
 
 ## Using Routers
@@ -30,14 +30,14 @@ Now you can use this component as a `screen` in another navigator, and the navig
 
 ## Customizing Routers
 
-See the [Custom Router API spec](/docs/custom-routers) to learn about the API of `StackRouter` and `TabRouter`. You can override the router functions as you see fit:
+See the [Custom Router API spec](custom-routers.html) to learn about the API of `StackRouter` and `TabRouter`. You can override the router functions as you see fit:
 
 ### Custom Navigation Actions
 
 To override navigation behavior, you can override the navigation state logic in `getStateForAction`, and manually manipulate the `routes` and `index`.
 
 ```js
-const MyApp = StackNavigator({
+const MyApp = createStackNavigator({
   Home: { screen: HomeScreen },
   Profile: { screen: ProfileScreen },
 }, {
@@ -103,7 +103,7 @@ Perhaps your app has a unique URI which the built-in routers cannot handle. You 
 
 import { NavigationActions } from 'react-navigation'
 
-const MyApp = StackNavigator({
+const MyApp = createStackNavigator({
   Home: { screen: HomeScreen },
   Profile: { screen: ProfileScreen },
 }, {


### PR DESCRIPTION
Hi, this PR fix some broken links to github source code in the routers documentation.

Here is link to test:
https://deploy-preview-359--react-navigation.netlify.com/docs/en/routers.html
https://deploy-preview-359--react-navigation.netlify.com/docs/en/2.x/routers.html
https://deploy-preview-359--react-navigation.netlify.com/docs/en/1.x/routers.html