### PR TITLE
Update tab-based-navigation.md

### DIFF
--- a/docs/tab-based-navigation.md
+++ b/docs/tab-based-navigation.md
@@ -36,8 +36,8 @@ class SettingsScreen extends React.Component {
 }
 
 const TabNavigator = createBottomTabNavigator({
-  Home: HomeScreen,
-  Settings: SettingsScreen,
+  Home: { screen: HomeScreen },
+  Settings: { screen: SettingsScreen }
 });
 
 export default createAppContainer(TabNavigator);
@@ -238,8 +238,8 @@ const SettingsStack = createStackNavigator({
 
 export default createAppContainer(createBottomTabNavigator(
   {
-    Home: HomeStack,
-    Settings: SettingsStack,
+    Home: { screen: HomeStack },
+    Settings: { screen: SettingsStack },
   },
   {
     /* Other configuration remains unchanged */


### PR DESCRIPTION
Added missing `{ screen: ScreenName }` in the code snippet for basic tabs and stack tabs.

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `website/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
