### PR TITLE
Clarify passing state params to tab + stack navigator routes where name is shared.

### DIFF
--- a/docs/tab-based-navigation.md
+++ b/docs/tab-based-navigation.md
@@ -249,6 +249,18 @@ export default createAppContainer(createBottomTabNavigator(
 
 <a href="https://snack.expo.io/@react-navigation/stacks-in-tabs-v3" target="blank" class="run-code-button">&rarr; Run this code</a>
 
+**Caveat** When you use the same name for both the tab and the stack, the navigation works, but passing state parameters will behave unintuitively. Any state params passed in when navigating to a route that is both the tab and the stack will only be available through accessing the parent via `dangerouslyGetParent()`.
+
+<a href="https://snack.expo.io/@andrewtc/stacks-in-tabs-passing-state-params" target="blank" class="run-code-button">&rarr; Run this code</a>
+
+You can avoid this situation by using different route names for the tab and stack. Since tabs use their route name for the label, it's often simpler to change the route name of the stack (to something such as `SettingsScreen`).
+
+<a href="https://snack.expo.io/@andrewtc/stacks-in-tabs-passing-state-params-(fixed)" target="blank" class="run-code-button">&rarr; Run this code</a>
+
+Or you can override the tab bar label for each stack navigator if you prefer to change the tab routes to something different (to something such as `SettingsTab`).
+
+<a href="https://snack.expo.io/@andrewtc/stacks-in-tabs-passing-state-params-(fixed-by-changing-tab-name)" target="blank" class="run-code-button">&rarr; Run this code</a>
+
 ## Why do we need a TabNavigator instead of TabBarIOS or some other component?
 
 It's common to attempt to use a standalone tab bar component without integrating it into the navigation library you use in your app. In some cases, this works fine! You should be warned, however, that you may run into some frustrating unanticipated issues when doing this.

--- a/website/versioned_docs/version-3.x/tab-based-navigation.md
+++ b/website/versioned_docs/version-3.x/tab-based-navigation.md
@@ -250,6 +250,18 @@ export default createAppContainer(createBottomTabNavigator(
 
 <a href="https://snack.expo.io/@react-navigation/stacks-in-tabs-v3" target="blank" class="run-code-button">&rarr; Run this code</a>
 
+**Caveat** When you use the same name for both the tab and the stack, the navigation works, but passing state parameters will behave unintuitively. Any state params passed in when navigating to a route that is both the tab and the stack will only be available through accessing the parent via `dangerouslyGetParent()`.
+
+<a href="https://snack.expo.io/@andrewtc/stacks-in-tabs-passing-state-params" target="blank" class="run-code-button">&rarr; Run this code</a>
+
+You can avoid this situation by using different route names for the tab and stack. Since tabs use their route name for the label, it's often simpler to change the route name of the stack (to something such as `SettingsScreen`).
+
+<a href="https://snack.expo.io/@andrewtc/stacks-in-tabs-passing-state-params-(fixed)" target="blank" class="run-code-button">&rarr; Run this code</a>
+
+Or you can override the tab bar label for each stack navigator if you prefer to change the tab routes to something different (to something such as `SettingsTab`).
+
+<a href="https://snack.expo.io/@andrewtc/stacks-in-tabs-passing-state-params-(fixed-by-changing-tab-name)" target="blank" class="run-code-button">&rarr; Run this code</a>
+
 ## Why do we need a TabNavigator instead of TabBarIOS or some other component?
 
 It's common to attempt to use a standalone tab bar component without integrating it into the navigation library you use in your app. In some cases, this works fine! You should be warned, however, that you may run into some frustrating unanticipated issues when doing this.


### PR DESCRIPTION
The Tabs Navigation documentation provides an example of putting a StackNavigator on a tab route. In the example, the name for the tab and the stack are the same: `Home` or `Settings`.

It turns out that state params passed via `navigate` will not be accessible inside the StackNavigator, which may be obvious to someone deeply familiar with the library but not to casual users (such as myself).

This PR clarifies this behavior and provides a couple examples of how to resolve the situation, so that state params can be successfully passed to the StackNavigator.

If folks think this behavior is actually a bug or warrants some other helper methods that may make it easier to deal with situations like these, I'm all ears and would love to hear how I might contribute more.