### PR TITLE
new backbehaviors

### DIFF
--- a/docs/bottom-tab-navigator.md
+++ b/docs/bottom-tab-navigator.md
@@ -22,7 +22,7 @@ The route configs object is a mapping from route name to a route config, which t
 * `initialRouteName` - The routeName for the initial tab route when first loading.
 * `order` - Array of routeNames which defines the order of the tabs.
 * `paths` - Provide a mapping of routeName to path config, which overrides the paths set in the routeConfigs.
-* `backBehavior` - Should the back button cause a tab switch to the initial tab? If yes, set to `initialRoute`, otherwise `none`. Defaults to `initialRoute` behavior.
+* `backBehavior` - `initialRoute` to return to initial tab, `order` to return to previous tab, `history` to return to last visited tab, or `none`.
 * `lazy` - Defaults to `true`. If `false`, all tabs are rendered immediately. When `true`, tabs are rendered only when they are made active for the first time. Note: tabs are **not** re-rendered upon subsequent visits.
 * `tabBarComponent` - Optional, override component to use as the tab bar.
 * `tabBarOptions` - An object with the following properties:

--- a/docs/material-bottom-tab-navigator.md
+++ b/docs/material-bottom-tab-navigator.md
@@ -36,7 +36,7 @@ The route configs object is a mapping from route name to a route config.
 * `initialRouteName` - The routeName for the initial tab route when first loading.
 * `order` - Array of routeNames which defines the order of the tabs.
 * `paths` - Provide a mapping of routeName to path config, which overrides the paths set in the routeConfigs.
-* `backBehavior` - Should the back button cause a tab switch to the initial tab? If yes, set to `initialRoute`, otherwise `none`. Defaults to `initialRoute` behavior.
+* `backBehavior` - `initialRoute` to return to initial tab, `order` to return to previous tab, `history` to return to last visited tab, or `none`.
 
 Example:
 

--- a/docs/material-top-tab-navigator.md
+++ b/docs/material-top-tab-navigator.md
@@ -19,7 +19,7 @@ The route configs object is a mapping from route name to a route config.
 * `initialRouteName` - The routeName for the initial tab route when first loading.
 * `order` - Array of routeNames which defines the order of the tabs.
 * `paths` - Provide a mapping of routeName to path config, which overrides the paths set in the routeConfigs.
-* `backBehavior` - Should the back button cause a tab switch to the initial tab? If yes, set to `initialRoute`, otherwise `none`. Defaults to `initialRoute` behavior.
+* `backBehavior` - `initialRoute` to return to initial tab, `order` to return to previous tab, `history` to return to last visited tab, or `none`.
 * `tabBarPosition` - Position of the tab bar, can be `'top'` or `'bottom'`, default is `top`.
 * `swipeEnabled` - Whether to allow swiping between tabs.
 * `animationEnabled` - Whether to animate when changing tabs.

--- a/docs/switch-navigator.md
+++ b/docs/switch-navigator.md
@@ -24,7 +24,7 @@ Several options get passed to the underlying router to modify navigation logic:
 - `initialRouteName` - The routeName for the initial tab route when first loading.
 - `resetOnBlur` - Reset the state of any nested navigators when switching away from a screen. Defaults to `true`.
 - `paths` - Provide a mapping of routeName to path config, which overrides the paths set in the routeConfigs.
-- `backBehavior` - Should the back button cause a tab switch to the initial route? If yes, set to `initialRoute`, otherwise `none`. Defaults to `none` behavior.
+- `backBehavior` - `initialRoute` to return to initial route, `order` to return to previous route, `history` to return to last visited route, or `none`.
 
 ## Example
 

--- a/docs/tab-navigator.md
+++ b/docs/tab-navigator.md
@@ -30,7 +30,7 @@ Several options get passed to the underlying router to modify navigation logic:
 * `initialRouteName` - The routeName for the initial tab route when first loading.
 * `order` - Array of routeNames which defines the order of the tabs.
 * `paths` - Provide a mapping of routeName to path config, which overrides the paths set in the routeConfigs.
-* `backBehavior` - Should the back button cause a tab switch to the initial tab? If yes, set to `initialRoute`, otherwise `none`. Defaults to `initialRoute` behavior.
+* `backBehavior` - `initialRoute` to return to initial tab, `order` to return to previous tab, `history` to return to last visited tab, or `none`.
 
 ### `tabBarOptions` for `TabBarBottom` (default tab bar on iOS)
 

--- a/website/versioned_docs/version-3.x/bottom-tab-navigator.md
+++ b/website/versioned_docs/version-3.x/bottom-tab-navigator.md
@@ -23,7 +23,7 @@ The route configs object is a mapping from route name to a route config, which t
 * `initialRouteName` - The routeName for the initial tab route when first loading.
 * `order` - Array of routeNames which defines the order of the tabs.
 * `paths` - Provide a mapping of routeName to path config, which overrides the paths set in the routeConfigs.
-* `backBehavior` - Should the back button cause a tab switch to the initial tab? If yes, set to `initialRoute`, otherwise `none`. Defaults to `initialRoute` behavior.
+* `backBehavior` - `initialRoute` to return to initial tab, `order` to return to previous tab, `history` to return to last visited tab, or `none`.
 * `lazy` - Defaults to `true`. If `false`, all tabs are rendered immediately. When `true`, tabs are rendered only when they are made active for the first time. Note: tabs are **not** re-rendered upon subsequent visits.
 * `tabBarComponent` - Optional, override component to use as the tab bar.
 * `tabBarOptions` - An object with the following properties:

--- a/website/versioned_docs/version-3.x/switch-navigator.md
+++ b/website/versioned_docs/version-3.x/switch-navigator.md
@@ -25,7 +25,7 @@ Several options get passed to the underlying router to modify navigation logic:
 - `initialRouteName` - The routeName for the initial tab route when first loading.
 - `resetOnBlur` - Reset the state of any nested navigators when switching away from a screen. Defaults to `true`.
 - `paths` - Provide a mapping of routeName to path config, which overrides the paths set in the routeConfigs.
-- `backBehavior` - Should the back button cause a tab switch to the initial route? If yes, set to `initialRoute`, otherwise `none`. Defaults to `none` behavior.
+- `backBehavior` - `initialRoute` to return to initial route, `order` to return to previous route, `history` to return to last visited route, or `none`.
 
 ## Example
 


### PR DESCRIPTION
I've edited the all the docs for new history/order switchrouter backbehaviors in v3/next

@brentvatne I've decided to not document this for Drawer navigator, as I think those behaviors do not make sense it would confuse users.