### PR TITLE
Remove nonexistent icon from tab-based-navigation.md

### DIFF
--- a/docs/tab-based-navigation.md
+++ b/docs/tab-based-navigation.md
@@ -72,7 +72,7 @@ export default createBottomTabNavigator(
           // You can check the implementation below.
           IconComponent = HomeIconWithBadge; 
         } else if (routeName === 'Settings') {
-          iconName = `ios-options${focused ? '' : '-outline'}`;
+          iconName = `ios-options`;
         }
 
         // You can return any component that you like here!

--- a/website/versioned_docs/version-3.x/tab-based-navigation.md
+++ b/website/versioned_docs/version-3.x/tab-based-navigation.md
@@ -73,7 +73,7 @@ export default createBottomTabNavigator(
           // You can check the implementation below.
           IconComponent = HomeIconWithBadge; 
         } else if (routeName === 'Settings') {
-          iconName = `ios-options${focused ? '' : '-outline'}`;
+          iconName = `ios-options`;
         }
 
         // You can return any component that you like here!


### PR DESCRIPTION
`tab-based-navigation.md` was trying to use `ios-options-outline` from `Ionicons` which doesn't exist. Removed that code so that now the `Settings` icon in the example only uses `ios-options`.
