### PR TITLE
Add documentation for deep linking in nested navigators

### DIFF
--- a/docs/deep-linking.md
+++ b/docs/deep-linking.md
@@ -29,6 +29,35 @@ const SimpleApp = createAppContainer(createStackNavigator({
 }));
 ```
 
+If we have nested navigators, we need to provide each parent screen with a `path`. All the paths will be concatenated and can also be an empty string. This path spec would be `friends/chat/:user`.
+
+```js
+const AuthSwitch = createAppContainer(createStackNavigator({
+  AuthLoading:  { screen: AuthLoadingScreen },
+  App: {
+    screen: AppStack,
+    path: '',
+  },
+  Auth: { screen: AuthStack },
+}));
+
+const AppStack = createStackNavigator({
+  Home: { screen: HomeScreen },
+  Friends: {
+    screen: FriendsScreen,
+    path: 'friends',
+  },
+});
+
+const FriendsScreen = createStackNavigator({
+  Overview: { screen: OverviewScreen },
+  Chat: {
+    screen: ChatScreen,
+    path: 'chat/:user',
+  },
+});
+```
+
 ## Set up with Expo projects
 
 First, you will want to specify a url scheme for your app. This corresponds to the string before `://` in a url, so if your scheme is `mychat` then a link to your app would be `mychat://`. The scheme only applies to standalone apps and you need to re-build the standalone app for the change to take effect. In the Expo client app you can deep link using `exp://ADDRESS:PORT` where `ADDRESS` is often `127.0.0.1` and `PORT` is often `19000` - the URL is printed when you run `expo start`. If you want to test with your custom scheme you will need to run `expo build:ios -t simulator` or `expo build:android` and install the resulting binaries in your emulators. You can register for a scheme in your `app.json` by adding a string under the scheme key:

--- a/website/versioned_docs/version-3.x/deep-linking.md
+++ b/website/versioned_docs/version-3.x/deep-linking.md
@@ -30,6 +30,35 @@ const SimpleApp = createAppContainer(createStackNavigator({
 }));
 ```
 
+If we have nested navigators, we need to provide each parent screen with a `path`. All the paths will be concatenated and can also be an empty string. This path spec would be `friends/chat/:user`.
+
+```js
+const AuthSwitch = createAppContainer(createStackNavigator({
+  AuthLoading:  { screen: AuthLoadingScreen },
+  App: {
+    screen: AppStack,
+    path: '',
+  },
+  Auth: { screen: AuthStack },
+}));
+
+const AppStack = createStackNavigator({
+  Home: { screen: HomeScreen },
+  Friends: {
+    screen: FriendsScreen,
+    path: 'friends',
+  },
+});
+
+const FriendsScreen = createStackNavigator({
+  Overview: { screen: OverviewScreen },
+  Chat: {
+    screen: ChatScreen,
+    path: 'chat/:user',
+  },
+});
+```
+
 ## Set up with Expo projects
 
 You need to specify a scheme for your app. You can register for a scheme in your `app.json` by adding a string under the scheme key:


### PR DESCRIPTION
This PR Fixes #387 by adding documentation to deep linking in nested navigators.
