### PR TITLE
fix(docs): No 'original_id' field found & The 'id' field missing the …

### DIFF
--- a/website/versioned_docs/version-3.x/navigation-views.md
+++ b/website/versioned_docs/version-3.x/navigation-views.md
@@ -1,7 +1,8 @@
 ---
-id: navigation-views
+id: version-3.x-navigation-views
 title: Navigation views
 sidebar_label: Navigation views
+original_id: navigation-views
 ---
 
 Navigation views are presentation components that take a [`router`](routers.html) and a [`navigation`](navigation-prop.html) prop, and can display several screens, as specified by the `navigation.state`.

--- a/website/versioned_docs/version-3.x/transitioner.md
+++ b/website/versioned_docs/version-3.x/transitioner.md
@@ -1,5 +1,6 @@
 ---
-id: transitioner
+id: version-3.x-transitioner
+original_id: transitioner
 title: Transitioner
 sidebar_label: Transitioner
 ---


### PR DESCRIPTION
…expected 'version-XX-' prefix

No 'original_id' field found in version-3.x/navigation-views.md and version-3.x/transitioner.md ;
The 'id' field missing the expected 'version-XX-' prefix in version-3.x/navigation-views.md and
version-3.x/transitioner.md

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `website/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
