### PR TITLE
Fix link to 'Screen Tracking for Analytics' page from 'Deep Linking' page.

### DIFF
--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -785,7 +785,7 @@
         "title": "Routers",
         "sidebar_label": "Routers"
       },
-      "version-3.x-screen-tracking-analytics": {
+      "version-3.x-screen-tracking": {
         "title": "Screen tracking for analytics",
         "sidebar_label": "Screen tracking for analytics"
       },

--- a/website/versioned_docs/version-3.x/screen-tracking.md
+++ b/website/versioned_docs/version-3.x/screen-tracking.md
@@ -1,5 +1,5 @@
 ---
-id: version-3.x-screen-tracking-analytics
+id: version-3.x-screen-tracking
 title: Screen tracking for analytics
 sidebar_label: Screen tracking for analytics
 original_id: screen-tracking

--- a/website/versioned_sidebars/version-3.x-sidebars.json
+++ b/website/versioned_sidebars/version-3.x-sidebars.json
@@ -28,7 +28,7 @@
       "version-3.x-navigating-without-navigation-prop",
       "version-3.x-navigation-key",
       "version-3.x-deep-linking",
-      "version-3.x-screen-tracking-analytics",
+      "version-3.x-screen-tracking",
       "version-3.x-themes",
       "version-3.x-state-persistence",
       "version-3.x-redux-integration",


### PR DESCRIPTION
*Issue:* [Link to 'Screen Tracking for Analytics' page from 'Deep Linking' page is broken #410](https://github.com/react-navigation/react-navigation.github.io/issues/410)

*Summary:* Small fix for a broken link in the live version of the website.