### PR TITLE
Adding link to API documentation

### DIFF
--- a/docs/drawer-based-navigation.md
+++ b/docs/drawer-based-navigation.md
@@ -4,6 +4,8 @@ title: Drawer navigation
 sidebar_label: Drawer navigation
 ---
 
+This guide covers [createDrawerNavigator](https://reactnavigation.org/docs/en/drawer-navigator.html). 
+
 ```js
 class MyHomeScreen extends React.Component {
   static navigationOptions = {

--- a/docs/drawer-based-navigation.md
+++ b/docs/drawer-based-navigation.md
@@ -3,7 +3,6 @@ id: drawer-based-navigation
 title: Drawer navigation
 sidebar_label: Drawer navigation
 ---
-
 This guide covers [createDrawerNavigator](https://reactnavigation.org/docs/en/drawer-navigator.html). 
 
 ```js

--- a/docs/drawer-based-navigation.md
+++ b/docs/drawer-based-navigation.md
@@ -3,7 +3,7 @@ id: drawer-based-navigation
 title: Drawer navigation
 sidebar_label: Drawer navigation
 ---
-This guide covers [createDrawerNavigator](https://reactnavigation.org/docs/en/drawer-navigator.html). 
+This guide covers [createDrawerNavigator](drawer-navigator.html). 
 
 ```js
 class MyHomeScreen extends React.Component {

--- a/website/versioned_docs/version-3.x/drawer-based-navigation.md
+++ b/website/versioned_docs/version-3.x/drawer-based-navigation.md
@@ -4,7 +4,7 @@ title: Drawer navigation
 sidebar_label: Drawer navigation
 original_id: drawer-based-navigation
 ---
-This guide covers [createDrawerNavigator](https://reactnavigation.org/docs/en/drawer-navigator.html). 
+This guide covers [createDrawerNavigator](drawer-navigator.html). 
 
 ```js
 class MyHomeScreen extends React.Component {

--- a/website/versioned_docs/version-3.x/drawer-based-navigation.md
+++ b/website/versioned_docs/version-3.x/drawer-based-navigation.md
@@ -4,6 +4,7 @@ title: Drawer navigation
 sidebar_label: Drawer navigation
 original_id: drawer-based-navigation
 ---
+This guide covers [createDrawerNavigator](https://reactnavigation.org/docs/en/drawer-navigator.html). 
 
 ```js
 class MyHomeScreen extends React.Component {


### PR DESCRIPTION
These guides should always begin with a link to the relevant API documentation
