### PR TITLE
add trouble shooting section with new JSC guide

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,15 @@
+---
+id: troubleshooting
+title: Troubleshooting
+sidebar_label: Troubleshooting
+---
+
+Here you can find some solutions of common issues. These are not the library's bugs or your mistakes.
+
+### Android back button after using core-js `Symbol` polyfill
+
+Related issue: https://github.com/react-navigation/react-navigation/issues/5171
+
+This is due to the fact that by default in older `react-native` versions (`<=0.59.0`), the Javascript engine used in Android (JSC) was really outdated and missing some new and important features such as `Symbol`. However, you can easily upgrade the JSC yourself according to [this guide](https://github.com/react-community/jsc-android-buildscripts)
+
+> Please note that from `react-native@^0.59.0` and `expo@^31.0.0` the newer JSC Engine for Android is already included by default so you don't have to do anything :)

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -289,6 +289,10 @@
         "title": "Transitioner",
         "sidebar_label": "Transitioner"
       },
+      "troubleshooting": {
+        "title": "Troubleshooting",
+        "sidebar_label": "Troubleshooting"
+      },
       "web-support": {
         "title": "React Navigation on the Web",
         "sidebar_label": "Web support"

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -685,6 +685,10 @@
         "title": "Transitioner",
         "sidebar_label": "Transitioner"
       },
+      "version-2.x-troubleshooting": {
+        "title": "Troubleshooting",
+        "sidebar_label": "Troubleshooting"
+      },
       "version-2.x-with-navigation-focus": {
         "title": "withNavigationFocus",
         "sidebar_label": "withNavigationFocus"
@@ -872,6 +876,10 @@
       "version-3.x-transitioner": {
         "title": "Transitioner",
         "sidebar_label": "Transitioner"
+      },
+      "version-3.x-troubleshooting": {
+        "title": "Troubleshooting",
+        "sidebar_label": "Troubleshooting"
       },
       "version-3.x-web-support": {
         "title": "React Navigation on the Web",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -47,6 +47,7 @@
       "transitioner"
     ],
     "Additional Resources": [
+      "troubleshooting",
       "community-libraries-and-navigators",
       "more-resources"
     ],

--- a/website/versioned_docs/version-2.x/troubleshooting.md
+++ b/website/versioned_docs/version-2.x/troubleshooting.md
@@ -1,0 +1,16 @@
+---
+id: version-2.x-troubleshooting
+title: Troubleshooting
+sidebar_label: Troubleshooting
+original_id: troubleshooting
+---
+
+Here you can find some solutions of common issues. These are not the library's bugs or your mistakes.
+
+### Android back button after using core-js `Symbol` polyfill
+
+Related issue: https://github.com/react-navigation/react-navigation/issues/5171
+
+This is due to the fact that by default in older `react-native` versions (`<=0.59.0`), the Javascript engine used in Android (JSC) was really outdated and missing some new and important features such as `Symbol`. However, you can easily upgrade the JSC yourself according to [this guide](https://github.com/react-community/jsc-android-buildscripts)
+
+> Please note that from `react-native@^0.59.0` and `expo@^31.0.0` the newer JSC Engine for Android is already included by default so you don't have to do anything :)

--- a/website/versioned_docs/version-3.x/troubleshooting.md
+++ b/website/versioned_docs/version-3.x/troubleshooting.md
@@ -1,0 +1,16 @@
+---
+id: version-3.x-troubleshooting
+title: Troubleshooting
+sidebar_label: Troubleshooting
+original_id: troubleshooting
+---
+
+Here you can find some solutions of common issues. These are not the library's bugs or your mistakes.
+
+### Android back button after using core-js `Symbol` polyfill
+
+Related issue: https://github.com/react-navigation/react-navigation/issues/5171
+
+This is due to the fact that by default in older `react-native` versions (`<=0.59.0`), the Javascript engine used in Android (JSC) was really outdated and missing some new and important features such as `Symbol`. However, you can easily upgrade the JSC yourself according to [this guide](https://github.com/react-community/jsc-android-buildscripts)
+
+> Please note that from `react-native@^0.59.0` and `expo@^31.0.0` the newer JSC Engine for Android is already included by default so you don't have to do anything :)

--- a/website/versioned_sidebars/version-2.x-sidebars.json
+++ b/website/versioned_sidebars/version-2.x-sidebars.json
@@ -42,6 +42,7 @@
       "version-2.x-transitioner"
     ],
     "Related Resources": [
+      "version-2.x-troubleshooting",
       "version-2.x-community-libraries-and-navigators",
       "version-2.x-more-resources"
     ],

--- a/website/versioned_sidebars/version-3.x-sidebars.json
+++ b/website/versioned_sidebars/version-3.x-sidebars.json
@@ -47,6 +47,7 @@
       "version-3.x-transitioner"
     ],
     "Related Resources": [
+      "version-2.x-troubleshooting",
       "version-3.x-community-libraries-and-navigators",
       "version-3.x-more-resources"
     ],

--- a/website/versioned_sidebars/version-3.x-sidebars.json
+++ b/website/versioned_sidebars/version-3.x-sidebars.json
@@ -47,7 +47,7 @@
       "version-3.x-transitioner"
     ],
     "Related Resources": [
-      "version-2.x-troubleshooting",
+      "version-3.x-troubleshooting",
       "version-3.x-community-libraries-and-navigators",
       "version-3.x-more-resources"
     ],


### PR DESCRIPTION
https://github.com/react-navigation/react-navigation.github.io/issues/314

I'm suggesting we should keep a troubleshooting section for some general issues which is not necessary user's mistakes.