### PR TITLE
Change Stack Navigator component's name

### DIFF
--- a/docs/headers.md
+++ b/docs/headers.md
@@ -117,7 +117,7 @@ class HomeScreen extends React.Component {
 
 /* other code... */
 
-const RootStack = createStackNavigator(
+const AppNavigator = createStackNavigator(
   {
     Home: HomeScreen,
     Details: DetailsScreen,


### PR DESCRIPTION
In order to keep consistency on the terminology used across the examples, this component's name should be changed to AppNavigator

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `website/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
