### PR TITLE
Add docs for linking gesture handler on RN >= 0.60

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,7 +32,22 @@ yarn add react-native-gesture-handler
 # npm install react-native-gesture-handler
 ```
 
-Link all native dependencies:
+If you're on React Native >= 0.60, you need to [disable autolinking for `react-native-gesture-handler` first](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md#how-can-i-disable-autolinking-for-unsupported-library). To disable autolinking for it, create a `react-native.config.js` file in the root of your project with the following content:
+
+```js
+module.exports = {
+  dependencies: {
+    'react-native-gesture-handler': {
+      platforms: {
+        android: null,
+        ios: null,
+      },
+    },
+  },
+};
+```
+
+Then run the following to link it (for all React Native versions):
 
 ```bash
 react-native link react-native-gesture-handler

--- a/website/versioned_docs/version-3.x/getting-started.md
+++ b/website/versioned_docs/version-3.x/getting-started.md
@@ -33,7 +33,22 @@ yarn add react-native-gesture-handler
 # npm install --save react-native-gesture-handler
 ```
 
-Link all native dependencies:
+If you're on React Native >= 0.60, you need to [disable autolinking for `react-native-gesture-handler` first](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md#how-can-i-disable-autolinking-for-unsupported-library). To disable autolinking for it, create a `react-native.config.js` file in the root of your project with the following content:
+
+```js
+module.exports = {
+  dependencies: {
+    'react-native-gesture-handler': {
+      platforms: {
+        android: null,
+        ios: null,
+      },
+    },
+  },
+};
+```
+
+Then run the following to link it (for all React Native versions):
 
 ```bash
 react-native link react-native-gesture-handler


### PR DESCRIPTION
In the docs, I have added config to disable autolinking on both Android and iOS so that linking is easier with `react-native-link`. Otherwise the user needs to run `git checkout ios` to revert the changes which is another extra step there.

I haven't tested this. Just sent PR because people are having trouble and this is what I found.

cc @thymikee