### PR TITLE
Add warning about remote debugging

### DIFF
--- a/docs/deep-linking.md
+++ b/docs/deep-linking.md
@@ -164,6 +164,8 @@ xcrun simctl openurl booted mychat://chat/Eric
 
 To test the URI on a real device, open Safari and type `mychat://chat/Eric`.
 
+**warning:** If react-native remote debugging is enabled and the app is not already running (foreground or background) deep linking will not work. To test deep linking to your app from a closed state, disable remote debugging. 
+
 ### Android
 
 To configure the external linking in Android, you can create a new intent in the manifest.

--- a/website/versioned_docs/version-3.x/deep-linking.md
+++ b/website/versioned_docs/version-3.x/deep-linking.md
@@ -163,6 +163,8 @@ xcrun simctl openurl booted mychat://chat/Eric
 
 To test the URI on a real device, open Safari and type `mychat://chat/Eric`.
 
+**warning:** If react-native remote debugging is enabled and the app is not already running (foreground or background) deep linking will not work. To test deep linking to your app from a closed state, disable remote debugging. 
+
 ### Android
 
 To configure the external linking in Android, you can create a new intent in the manifest.


### PR DESCRIPTION
Deep-linking does not function as expected when the remote debugger is enabled. If the app is already running on the phone (foreground or background) it works as expected, but if the app is closed opening a link will only ever open the initial route. This is an annoying and opaque issue to diagnose and it would be a boon to developers to be warned about it in the documentation.