### PR TITLE
Fix typo in “Hello React Navigation > Creating a stack navigator” section

### DIFF
--- a/website/versioned_docs/version-4.x/hello-react-navigation.md
+++ b/website/versioned_docs/version-4.x/hello-react-navigation.md
@@ -15,7 +15,7 @@ Before continuing, first install [`react-navigation-stack`](https://github.com/r
 
 ## Creating a stack navigator
 
-`createStackNavigator` is a function that returns a React component. It takes _a route configuration object_ and, optionally, _an options object_ (we omit this below, for now). `createAppContainer` is a function that retuns a React component to take as a parameter the React component created by the `createStackNavigator`, and can be directly exported from `App.js` to be used as our App's root component.
+`createStackNavigator` is a function that returns a React component. It takes _a route configuration object_ and, optionally, _an options object_ (we omit this below, for now). `createAppContainer` is a function that returns a React component to take as a parameter the React component created by the `createStackNavigator`, and can be directly exported from `App.js` to be used as our App's root component.
 
 ```js
 // In App.js in a new project


### PR DESCRIPTION
```diff
- `createAppContainer` is a function that retuns a React component to take as a parameter
+ `createAppContainer` is a function that returns a React component to take as a parameter
```

URL: https://reactnavigation.org/docs/en/hello-react-navigation.html#creating-a-stack-navigator