### PR TITLE
fix docs typo: screenOptopns => screenOptions

### DIFF
--- a/docs/tab-based-navigation.md
+++ b/docs/tab-based-navigation.md
@@ -63,7 +63,7 @@ export default function App() {
   return (
     <NavigationNativeContainer>
       <Tab.Navigator
-        screenOptopns={({ route }) => {
+        screenOptions={({ route }) => {
           let IconComponent = Ionicons;
           let iconName;
 


### PR DESCRIPTION
This doesn't seem to be an issue in other doc versions since they don't use the component-based API.