### PR TITLE
docs typo: use defaultNavigationOptions tab navigator

### DIFF
--- a/website/versioned_docs/version-4.x/tab-based-navigation.md
+++ b/website/versioned_docs/version-4.x/tab-based-navigation.md
@@ -64,7 +64,7 @@ export default createBottomTabNavigator(
     Settings: SettingsScreen,
   },
   {
-    navigationOptions: ({ navigation }) => ({
+    defaultNavigationOptions: ({ navigation }) => ({
       tabBarIcon: ({ focused, horizontal, tintColor }) => {
         const { routeName } = navigation.state;
         let IconComponent = Ionicons;


### PR DESCRIPTION
This only seems to be an issue in v4 of the docs. v3 correctly uses `defaultNavigationOptions` and vNext uses a different API and had a separate issue (#482). Also worth noting that the linked snack correctly has `defaultNavigationOptions`. 

Totally didn't spend half an hour to figure out this was a bug in the docs 😬