### PR TITLE
Update title and label for useIsFocused

### DIFF
--- a/docs/use-is-focused.md
+++ b/docs/use-is-focused.md
@@ -1,7 +1,7 @@
 ---
 id: use-is-focused
-title: useFocusEffect
-sidebar_label: useFocusEffect
+title: useIsFocused
+sidebar_label: useIsFocused
 ---
 
 We might want to render different content based on the current focus state of the screen. The library exports a `useIsFocused` hook to make this easier:


### PR DESCRIPTION
The title and side label where wrong: "useFocusEffect" instead of "useIsFocused"

Didn't add the `website/versioned_docs` change because there is no versioned docs for the next release