### PR TITLE
Function call need to be make to create Ref

### DIFF
--- a/docs/navigating-without-navigation-prop.md
+++ b/docs/navigating-without-navigation-prop.md
@@ -30,7 +30,7 @@ In the next step, we define `NavigationService` which is a simple module with fu
 
 import * as React from 'react';
 
-export const navigationRef = React.createRef;
+export const navigationRef = React.createRef();
 
 export function navigate(name, params) {
   navigationRef.current && navigationRef.current.navigate(name, params);


### PR DESCRIPTION
In code it is written
```js
export const navigationRef = React.createRef
```

But to create ref, functional call need to be made
```js
export const navigationRef = React.createRef();
```

