### PR TITLE
Different dependency mentioned in drawer-based-navigation.md

### DIFF
--- a/docs/drawer-based-navigation.md
+++ b/docs/drawer-based-navigation.md
@@ -6,13 +6,7 @@ sidebar_label: Drawer navigation
 
 Common pattern in navigation is to use drawer from left (sometimes right) site for navigating between screens.
 
-This guide covers [createDrawerNavigator](drawer-navigator.html).
-
-To use this navigator, you need to install `@react-navigation/drawer` and its peer dependencies:
-
-```sh
-yarn add react-navigation-drawer react-native-reanimated react-native-gesture-handler
-```
+Before continuing, first install `@react-navigation/drawer` following the guide on [Drawer Navigator's page](drawer-navigator.md).
 
 ## Minimal example of drawer-based navigation
 

--- a/docs/drawer-based-navigation.md
+++ b/docs/drawer-based-navigation.md
@@ -6,7 +6,7 @@ sidebar_label: Drawer navigation
 
 Common pattern in navigation is to use drawer from left (sometimes right) site for navigating between screens.
 
-Before continuing, first install [`@react-navigation/drawer`](https://github.com/navigation-ex/packages/drawer) following the guide on [Drawer Navigator's page](drawer-navigator.md).
+Before continuing, first install [`@react-navigation/drawer`](https://github.com/navigation-ex/packages/drawer) following the guide on [Drawer Navigator's page](drawer-navigator.html).
 
 ## Minimal example of drawer-based navigation
 

--- a/docs/drawer-based-navigation.md
+++ b/docs/drawer-based-navigation.md
@@ -6,7 +6,7 @@ sidebar_label: Drawer navigation
 
 Common pattern in navigation is to use drawer from left (sometimes right) site for navigating between screens.
 
-Before continuing, first install `@react-navigation/drawer` following the guide on [Drawer Navigator's page](drawer-navigator.md).
+Before continuing, first install [`@react-navigation/drawer`](https://github.com/navigation-ex/packages/drawer) following the guide on [Drawer Navigator's page](drawer-navigator.md).
 
 ## Minimal example of drawer-based navigation
 

--- a/docs/navigation-context.md
+++ b/docs/navigation-context.md
@@ -11,6 +11,8 @@ Most of the time, you won't use `NavigationContext` directly, as the provided `u
 Example:
 
 ```js
+import { NavigationContext } from '@react-navigation/core';
+
 class SomeComponent extends React.Component {
   static contextType = NavigationContext;
 


### PR DESCRIPTION
In [`drawer-based-navigation`](https://reactnavigation.org/docs/en/next/drawer-based-navigation.html) it is mentioned to install `react-navigation-drawer` whereas in [`drawer-navigator`](https://reactnavigation.org/docs/en/next/drawer-navigator.html) it is mentioned to install ` @react-navigation/drawer`

I changed the docs to reflect installation mentioned in [`drawer-navigator`](https://reactnavigation.org/docs/en/next/drawer-navigator.html) Page
I also tested drawer navigation by installing `@react-navigation/drawer` and it is working fine
