### PR TITLE
Add documentation for labelPosition option in createBottomTabNavigator

### DIFF
--- a/docs/bottom-tab-navigator.md
+++ b/docs/bottom-tab-navigator.md
@@ -78,6 +78,7 @@ An object containing the props for the tab bar component. It can contain the fol
 - `showIcon` - Whether to show icon for tab, default is true.
 - `style` - Style object for the tab bar.
 - `labelStyle` - Style object for the tab label.
+- `labelPosition` - Where to show the tab label in relation to the tab icon. Available values are `beside-icon` and `below-icon`. Defaults to `beside-icon`.
 - `tabStyle` - Style object for the tab.
 - `allowFontScaling` - Whether label font should scale to respect Text Size accessibility settings, default is true.
 - `adaptive` - Should the tab icons and labels alignment change based on screen size? Defaults to `true` for iOS 11. If `false`, tab icons and labels align vertically all the time. When `true`, tab icons and labels align horizontally on tablet.

--- a/website/versioned_docs/version-4.x/bottom-tab-navigator.md
+++ b/website/versioned_docs/version-4.x/bottom-tab-navigator.md
@@ -47,6 +47,7 @@ The route configs object is a mapping from route name to a route config, which t
   - `showIcon` - Whether to show icon for tab, default is true.
   - `style` - Style object for the tab bar.
   - `labelStyle` - Style object for the tab label.
+  - `labelPosition` - Where to show the tab label in relation to the tab icon. Available values are `beside-icon` and `below-icon`. Defaults to `beside-icon`.
   - `tabStyle` - Style object for the tab.
   - `allowFontScaling` - Whether label font should scale to respect Text Size accessibility settings, default is true.
   - `adaptive` - Should the tab icons and labels alignment change based on screen size? Defaults to `true` for iOS 11. If `false`, tab icons and labels align vertically all the time. When `true`, tab icons and labels align horizontally on tablet.
@@ -74,13 +75,16 @@ import { createBottomTabNavigator, BottomTabBar } from 'react-navigation-tabs';
 
 const TabBarComponent = props => <BottomTabBar {...props} />;
 
-const TabScreens = createBottomTabNavigator({
-  // other screens
-}, {
-  tabBarComponent: props => (
-    <TabBarComponent {...props} style={{ borderTopColor: '#605F60' }} />
-  ),
-});
+const TabScreens = createBottomTabNavigator(
+  {
+    // other screens
+  },
+  {
+    tabBarComponent: props => (
+      <TabBarComponent {...props} style={{ borderTopColor: '#605F60' }} />
+    ),
+  }
+);
 ```
 
 ## `navigationOptions` for screens inside of the navigator


### PR DESCRIPTION
Hi,

I noticed that the labelPosition options is missing in the documentation, so I added it :) I am not sure about to which versions I should add it in the documentation. It was released with @react-navigation/tabs 2.3.0, but the versions here in the website repo look like they refer to the versions of the main package. If you give me a hint which versions should be updated, I can update the PR.

Regards
Josef
