### PR TITLE
Fix typo in useIsFocused API docs

### DIFF
--- a/docs/use-is-focused.md
+++ b/docs/use-is-focused.md
@@ -1,7 +1,7 @@
 ---
 id: use-is-focused
-title: useFocusEffect
-sidebar_label: useFocusEffect
+title: useIsFocused
+sidebar_label: useIsFocused
 ---
 
 We might want to render different content based on the current focus state of the screen. The library exports a `useIsFocused` hook to make this easier:


### PR DESCRIPTION
The `title` and `sidebar_label` of the `useIsFocused` documentation were set to `useFocusEffect`. Hooks are only in the `next` version, so I don't think it needs to be updated anywhere else.