### PR TITLE
Fix demo app link on index page is 404 - Closes #510

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -59,7 +59,7 @@ class HomeSplash extends React.Component {
                     >
                       <translate>Read API Reference</translate>
                     </Button>
-                    <Button href="https://github.com/react-navigation/react-navigation/tree/master/examples/NavigationPlayground">
+                    <Button href="https://github.com/react-navigation/react-navigation/tree/master/example">
                       <translate>Try the demo app</translate>
                     </Button>
                   </div>


### PR DESCRIPTION
Noticed the demo app link on the index page is `404`. I just pointed the url to the new location for the example app. Although I wonder if the user experience could be improved if the button were to just link to the in-browser demo @ https://expo.io/@react-navigation/NavigationPlayground
