### PR TITLE
change defaultOptions -> screenOptions

### DIFF
--- a/docs/headers.md
+++ b/docs/headers.md
@@ -169,4 +169,4 @@ You can read the full list of available `options` for screens inside of a stack 
 
 - You can customize the header inside of the `options` prop of your screen components. Read the full list of options [in the API reference](stack-navigator.html#navigationoptions-used-by-stacknavigator).
 - The `options` prop can be an object or a function. When it is a function, it is provided with an object with the `navigation` and `route` prop.
-- You can also specify shared `defaultOptions` in the stack navigator configuration when you initialize it. The prop takes precedence over that configuration.
+- You can also specify shared `screenOptions` in the stack navigator configuration when you initialize it. The prop takes precedence over that configuration.


### PR DESCRIPTION
### TL;DR: Make sure to add your changes to versioned docs

I found that react-navigation 5.x has screenOptions, but not defaultOptions. This PR fixes documentation referencing to defaultOptions.