### PR TITLE
Fix(doc-4.x): Add required configuration

### DIFF
--- a/website/versioned_docs/version-4.x/getting-started.md
+++ b/website/versioned_docs/version-4.x/getting-started.md
@@ -92,6 +92,13 @@ Next, we need to link these libraries. The steps depends on your React Native ve
   # npm install --save-dev jetifier
   ```
 
+  Next, add these two lines in `gradle.properties` under `android` folder
+
+  ```sh
+  android.useAndroidX=true
+  android.enableJetifier=true
+  ```
+
   Then add it to the `postinstall` script in `package.json`:
 
   ```json


### PR DESCRIPTION
# Minor Addition In Doc: 4.x

After following the doc for `React Native 0.59 and lower`, mostly users getting error `Execution failed for task ':react-native-gesture-handler:compileDebugJavaWithJavac'` on running `react-native run-android`. I recently faced this issue as well. In order to resolve this issue we need to add required config values in `gradle.properties`. 
So in order to facilitate newbies & other users of this module. I've created this PR.
Please merge this PR, I will be really happy to be one of the contributor :+1:
