### PR TITLE
Fix Deep linking iOS docs using deprecated method

### DIFF
--- a/docs/deep-linking.md
+++ b/docs/deep-linking.md
@@ -231,11 +231,10 @@ In `SimpleApp/ios/SimpleApp/AppDelegate.m`:
 #import <React/RCTLinkingManager.h>
 
 // Add this above the `@end`:
-- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url
-  sourceApplication:(NSString *)sourceApplication annotation:(id)annotation
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
 {
-  return [RCTLinkingManager application:application openURL:url
-                      sourceApplication:sourceApplication annotation:annotation];
+  return [RCTLinkingManager application:app openURL:url options:options];
 }
 ```
 

--- a/website/versioned_docs/version-4.x/deep-linking.md
+++ b/website/versioned_docs/version-4.x/deep-linking.md
@@ -144,11 +144,10 @@ In `SimpleApp/ios/SimpleApp/AppDelegate.m`:
 #import <React/RCTLinkingManager.h>
 
 // Add this above the `@end`:
-- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url
-  sourceApplication:(NSString *)sourceApplication annotation:(id)annotation
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
 {
-  return [RCTLinkingManager application:application openURL:url
-                      sourceApplication:sourceApplication annotation:annotation];
+  return [RCTLinkingManager application:app openURL:url options:options];
 }
 ```
 


### PR DESCRIPTION
The Deep linking iOS docs indicate to use the long deprecated `appliation:openURL:sourceApplication:annotation:` method. Update to use preferred `application:openURL:options:` method.