### PR TITLE
Add react-native-header-scroll-view to Community-developed Navigators and Libraries

### DIFF
--- a/docs/community-libraries-and-navigators.md
+++ b/docs/community-libraries-and-navigators.md
@@ -62,7 +62,9 @@ Provides simple HOCs that map react-navigation props to your screen components d
 
 ## react-native-header-scroll-view
 
-This component addresses the most requested feature to React Navigation – [iOS large header and grow/shrink on scroll](https://react-navigation.canny.io/feature-requests/p/ios-11-large-header-and-growshrink-on-scroll), made by [@jonsamp](https://github.com/jonsamp). It is different than the actual iOS large header behavior, but does the header title shrinking well. It can be used with React Navigation by using the following code in your component:
+This component implements [iOS large header with grow/shrink on scroll](https://react-navigation.canny.io/feature-requests/p/ios-11-large-header-and-growshrink-on-scroll), made by [@jonsamp](https://github.com/jonsamp). Note that it doesn't handle header animation between screens, it only handles animating the header title on scroll.
+
+To use this component for header in React Navigation, we need to disable the default header:
 
 ```
   static navigationOptions = {

--- a/docs/community-libraries-and-navigators.md
+++ b/docs/community-libraries-and-navigators.md
@@ -59,3 +59,20 @@ Provides simple HOCs that map react-navigation props to your screen components d
 #### Links
 
 [github.com/vonovak/react-navigation-props-mapper](https://github.com/vonovak/react-navigation-props-mapper)
+
+## react-native-header-scroll-view
+
+This component addresses the most requested feature to React Navigation – [iOS large header and grow/shrink on scroll](https://react-navigation.canny.io/feature-requests/p/ios-11-large-header-and-growshrink-on-scroll), made by [@jonsamp](https://github.com/jonsamp). It is different than the actual iOS large header behavior, but does the header title shrinking well. It can be used with React Navigation by using the following code in your component:
+
+```
+  static navigationOptions = {
+    headerMode: "none",
+    header: null
+  };
+```
+
+#### Links
+
+[https://github.com/jonsamp/react-native-header-scroll-view](https://github.com/jonsamp/react-native-header-scroll-view)
+
+[Demo on expo via VaxNow](https://expo.io/@thomaswangio/vax-now)

--- a/docs/community-libraries-and-navigators.md
+++ b/docs/community-libraries-and-navigators.md
@@ -64,8 +64,6 @@ Provides simple HOCs that map react-navigation props to your screen components d
 
 This component implements [iOS large header with grow/shrink on scroll](https://react-navigation.canny.io/feature-requests/p/ios-11-large-header-and-growshrink-on-scroll), made by [@jonsamp](https://github.com/jonsamp). Note that it doesn't handle header animation between screens, it only handles animating the header title on scroll.
 
-headerMode is an option in createStackNavigator's config, not in navigationOptions. I'd document both, headerMode: 'none' to disable globally, and header: null to disable header for one screen.
-
 There are 2 ways to use this component for a header in React Navigation:
 
 1. Disable the default header for one screen:

--- a/docs/community-libraries-and-navigators.md
+++ b/docs/community-libraries-and-navigators.md
@@ -64,29 +64,28 @@ Provides simple HOCs that map react-navigation props to your screen components d
 
 This component implements [iOS large header with grow/shrink on scroll](https://react-navigation.canny.io/feature-requests/p/ios-11-large-header-and-growshrink-on-scroll), made by [@jonsamp](https://github.com/jonsamp). Note that it doesn't handle header animation between screens, it only handles animating the header title on scroll.
 
-There are 2 ways to use this component for a header in React Navigation:
+To use this component, we'd want to disable the built-in header. There are 2 ways to disable the header in React Navigation:
 
 1. Disable the default header for one screen:
 
-```
-  static navigationOptions = {
-    header: null
-  };
+```js
+static navigationOptions = {
+  header: null
+};
 ```
 
 2. Disable header globally in `createStackNavigator`
 
-```
+```js
 const Home = createStackNavigator(
   {
-    ExampleScreen1: ExampleScreen1,
-    ExampleScreen1: ExampleScreen2,
+    ExampleScreen1,
+    ExampleScreen1,
   },
   {
     headerMode: 'none'
   }
 );
-
 ```
 
 #### Links

--- a/docs/community-libraries-and-navigators.md
+++ b/docs/community-libraries-and-navigators.md
@@ -64,13 +64,31 @@ Provides simple HOCs that map react-navigation props to your screen components d
 
 This component implements [iOS large header with grow/shrink on scroll](https://react-navigation.canny.io/feature-requests/p/ios-11-large-header-and-growshrink-on-scroll), made by [@jonsamp](https://github.com/jonsamp). Note that it doesn't handle header animation between screens, it only handles animating the header title on scroll.
 
-To use this component for header in React Navigation, we need to disable the default header:
+headerMode is an option in createStackNavigator's config, not in navigationOptions. I'd document both, headerMode: 'none' to disable globally, and header: null to disable header for one screen.
+
+There are 2 ways to use this component for a header in React Navigation:
+
+1. Disable the default header for one screen:
 
 ```
   static navigationOptions = {
-    headerMode: "none",
     header: null
   };
+```
+
+2. Disable header globally in `createStackNavigator`
+
+```
+const Home = createStackNavigator(
+  {
+    ExampleScreen1: ExampleScreen1,
+    ExampleScreen1: ExampleScreen2,
+  },
+  {
+    headerMode: 'none'
+  }
+);
+
 ```
 
 #### Links


### PR DESCRIPTION
Love this little library from @jonsamp and adding it to `Community-developed Navigators and Libraries` after feedback from @satya164 on Twitter: https://twitter.com/satya164/status/1179174667552210944

