### PR TITLE
Fix broken links in 4.x docs for createStackNavigator API

### DIFF
--- a/website/versioned_docs/version-4.x/stack-navigator.md
+++ b/website/versioned_docs/version-4.x/stack-navigator.md
@@ -263,7 +263,7 @@ const SomeStack = createStackNavigator({
 
 ### Examples
 
-See the examples [SimpleStack.tsx](https://github.com/react-navigation/react-navigation/blob/v4.0.10/example/src/SimpleStack.tsx) and [ModalStack.tsx](https://github.com/react-navigation/react-navigation/blob/v4.0.10/example/src/ModalStack.tsx) which you can run locally as part of the [NavigationPlayground](https://github.com/react-navigation/react-navigation/tree/v4.0.10/example) app.
+See the examples [SimpleStack.tsx](https://github.com/react-navigation/react-navigation/blob/master/example/src/SimpleStack.tsx) and [ModalStack.tsx](https://github.com/react-navigation/react-navigation/blob/master/example/src/ModalStack.tsx) which you can run locally as part of the [NavigationPlayground](https://github.com/react-navigation/react-navigation/blob/master/example) app.
 
 You can view these examples directly on your phone by visiting [our expo demo](https://exp.host/@react-navigation/NavigationPlayground).
 

--- a/website/versioned_docs/version-4.x/stack-navigator.md
+++ b/website/versioned_docs/version-4.x/stack-navigator.md
@@ -263,7 +263,7 @@ const SomeStack = createStackNavigator({
 
 ### Examples
 
-See the examples [SimpleStack.tsx](https://github.com/react-navigation/react-navigation/blob/master/examples/NavigationPlayground/src/SimpleStack.tsx) and [ModalStack.tsx](https://github.com/react-navigation/react-navigation/blob/master/examples/NavigationPlayground/src/ModalStack.tsx) which you can run locally as part of the [NavigationPlayground](https://github.com/react-navigation/react-navigation/tree/master/examples/NavigationPlayground) app.
+See the examples [SimpleStack.tsx](https://github.com/react-navigation/react-navigation/blob/v4.0.10/example/src/SimpleStack.tsx) and [ModalStack.tsx](https://github.com/react-navigation/react-navigation/blob/v4.0.10/example/src/ModalStack.tsx) which you can run locally as part of the [NavigationPlayground](https://github.com/react-navigation/react-navigation/tree/v4.0.10/example) app.
 
 You can view these examples directly on your phone by visiting [our expo demo](https://exp.host/@react-navigation/NavigationPlayground).
 


### PR DESCRIPTION
The links under the `Examples` section on this page of the 4.x docs are broken:
https://reactnavigation.org/docs/en/stack-navigator.html