### PR TITLE
rename DrawerItems to DrawerNavigatorItems

### DIFF
--- a/docs/drawer-navigator.md
+++ b/docs/drawer-navigator.md
@@ -167,7 +167,7 @@ Whether a screen should be unmounted when navigating away from it. Defaults to `
 
 #### `contentComponent`
 
-Component used to render the content of the drawer, for example, navigation items. Receives the `navigation` prop and `drawerOpenProgress` for the drawer. Defaults to `DrawerItems`. For more information, see below.
+Component used to render the content of the drawer, for example, navigation items. Receives the `navigation` prop and `drawerOpenProgress` for the drawer. Defaults to `DrawerNavigatorItems`. For more information, see below.
 
 #### `contentOptions`
 
@@ -179,7 +179,7 @@ The default component for the drawer is scrollable and only contains links for t
 
 ```js
 import SafeAreaView from 'react-native-safe-area-view';
-import { DrawerItems } from '@react-navigation/drawer';
+import { DrawerNavigatorItems } from '@react-navigation/drawer';
 
 const CustomDrawerContentComponent = props => (
   <ScrollView>
@@ -187,7 +187,7 @@ const CustomDrawerContentComponent = props => (
       style={styles.container}
       forceInset={{ top: 'always', horizontal: 'never' }}
     >
-      <DrawerItems {...props} />
+      <DrawerNavigatorItems {...props} />
     </SafeAreaView>
   </ScrollView>
 );
@@ -216,7 +216,7 @@ const CustomDrawerContentComponent = props => {
 };
 ```
 
-### `contentOptions` for `DrawerItems`
+### `contentOptions` for `DrawerNavigatorItems`
 
 - `items` - the array of routes, can be modified or overridden
 - `activeItemKey` - key identifying the active route


### PR DESCRIPTION
Module '".…/node_modules/@react-navigation/drawer/lib/typescript/drawer/src"' has no exported member 'DrawerItems'.

but DrawerNavigatorItems works

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `website/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
