### PR TITLE
Fix broken link in tab-based-nav.md

### DIFF
--- a/docs/tab-based-navigation.md
+++ b/docs/tab-based-navigation.md
@@ -260,4 +260,4 @@ For example, React Navigation's tab navigator takes care of handling the Android
 
 ## A tab navigator contains a stack and you want to hide the tab bar on specific screens
 
-[See the documentation here](navigation-options-resolution.html#a-tab-navigator-contains-a-stack-and-you-want-to-hide-the-tab-bar-on-specific-screens)
+[See the documentation here](screen-options-resolution.html#a-tab-navigator-contains-a-stack-and-you-want-to-hide-the-tab-bar-on-specific-screens)


### PR DESCRIPTION
Changed the link at the bottom to point to screen-options-resolution rather than navigation-options.

The fix only pertains to next/5.x due to the renaming of navigation-options to screen-options.
