### PR TITLE
Fix transitionConfig types link

### DIFF
--- a/website/versioned_docs/version-4.x/stack-navigator.md
+++ b/website/versioned_docs/version-4.x/stack-navigator.md
@@ -82,7 +82,7 @@ Visual options:
 - `cardStyle` - Use this prop to override or extend the default style for an individual card in stack.
 - `cardShadowEnabled` - Use this prop to have visible shadows during transitions. Defaults to `true`
 - `cardOverlayEnabled` - Use this prop to have visible stack card overlays during transitions. Defaults to `false`.
-- `transitionConfig` - Function to return an object that is merged with the default screen transitions (take a look at TransitionConfig in [type definitions](https://github.com/react-navigation/stack/blob/v1.9.4/src/types.tsx#L232)). Provided function will be passed the following arguments:
+- `transitionConfig` - Function to return an object that is merged with the default screen transitions (take a look at TransitionConfig in [type definitions](https://github.com/react-navigation/stack/blob/1.0/src/types.tsx#L232)). Provided function will be passed the following arguments:
   - `transitionProps` - Transition props for the new screen.
   - `prevTransitionProps` - Transitions props for the old screen.
   - `isModal` - Boolean specifying if screen is modal.

--- a/website/versioned_docs/version-4.x/stack-navigator.md
+++ b/website/versioned_docs/version-4.x/stack-navigator.md
@@ -82,7 +82,7 @@ Visual options:
 - `cardStyle` - Use this prop to override or extend the default style for an individual card in stack.
 - `cardShadowEnabled` - Use this prop to have visible shadows during transitions. Defaults to `true`
 - `cardOverlayEnabled` - Use this prop to have visible stack card overlays during transitions. Defaults to `false`.
-- `transitionConfig` - Function to return an object that is merged with the default screen transitions (take a look at TransitionConfig in [type definitions](https://github.com/react-navigation/react-navigation/blob/master/flow/react-navigation.js)). Provided function will be passed the following arguments:
+- `transitionConfig` - Function to return an object that is merged with the default screen transitions (take a look at TransitionConfig in [type definitions](https://github.com/react-navigation/stack/blob/v1.9.4/src/types.tsx#L232)). Provided function will be passed the following arguments:
   - `transitionProps` - Transition props for the new screen.
   - `prevTransitionProps` - Transitions props for the old screen.
   - `isModal` - Boolean specifying if screen is modal.


### PR DESCRIPTION
The link explaining `TransitionConfig` is broken, so I've updated it to point to the type definitions on the ~~v1.9.4 tag~~ `1.0` branch. Since it's pointing to the ~~tag~~ branch instead of master it shouldn't break again. The transition config is gone in v5 so there's nothing to change in the original file.
