### PR TITLE
update(screen-tracking) change analytics module example

### DIFF
--- a/docs/screen-tracking.md
+++ b/docs/screen-tracking.md
@@ -17,10 +17,8 @@ This example shows how to do screen tracking and send to Google Analytics. The a
 
 ```js
 import * as React from 'react';
-import { GoogleAnalyticsTracker } from 'react-native-google-analytics-bridge';
+import analytics from '@react-native-firebase/analytics';
 import { NavigationNativeContainer } from '@react-navigation/native';
-
-const tracker = new GoogleAnalyticsTracker(GA_TRACKING_ID);
 
 // Gets the current screen from navigation state
 const getActiveRouteName = state => {
@@ -52,9 +50,9 @@ export default function App() {
           );
 
           if (previousRouteName !== currentRouteName) {
-            // The line below uses the Google Analytics tracker
+            // The line below uses the @react-native-firebase/analytics tracker
             // Change this line to use another Mobile analytics SDK
-            tracker.trackScreenView(currentRouteName);
+            analytics().setCurrentScreen(currentRouteName, currentRouteName);
           }
 
           // Save the current route name for later comparision

--- a/website/versioned_docs/version-3.x/screen-tracking.md
+++ b/website/versioned_docs/version-3.x/screen-tracking.md
@@ -11,9 +11,7 @@ This example shows how to do screen tracking and send to Google Analytics. The a
 
 ```js
 import { createAppContainer, createStackNavigator } from 'react-navigation';
-import { GoogleAnalyticsTracker } from 'react-native-google-analytics-bridge';
-
-const tracker = new GoogleAnalyticsTracker(GA_TRACKING_ID);
+import analytics from '@react-native-firebase/analytics';
 
 // gets the current screen from navigation state
 function getActiveRouteName(navigationState) {
@@ -34,13 +32,13 @@ const AppContainer = createAppContainer(AppNavigator);
 export default () => (
   <AppContainer
     onNavigationStateChange={(prevState, currentState, action) => {
-      const currentScreen = getActiveRouteName(currentState);
-      const prevScreen = getActiveRouteName(prevState);
+      const currentRouteName = getActiveRouteName(currentState);
+      const previousRouteName = getActiveRouteName(prevState);
 
-      if (prevScreen !== currentScreen) {
-        // the line below uses the Google Analytics tracker
+      if (previousRouteName !== currentRouteName) {
+        // The line below uses the @react-native-firebase/analytics tracker
         // change the tracker here to use other Mobile analytics SDK.
-        tracker.trackScreenView(currentScreen);
+        analytics().setCurrentScreen(currentRouteName, currentRouteName);
       }
     }}
   />

--- a/website/versioned_docs/version-4.x/screen-tracking.md
+++ b/website/versioned_docs/version-4.x/screen-tracking.md
@@ -11,9 +11,7 @@ This example shows how to do screen tracking and send to Google Analytics. The a
 
 ```js
 import { createAppContainer, createStackNavigator } from 'react-navigation';
-import { GoogleAnalyticsTracker } from 'react-native-google-analytics-bridge';
-
-const tracker = new GoogleAnalyticsTracker(GA_TRACKING_ID);
+import analytics from '@react-native-firebase/analytics';
 
 // gets the current screen from navigation state
 function getActiveRouteName(navigationState) {
@@ -34,13 +32,13 @@ const AppContainer = createAppContainer(AppNavigator);
 export default () => (
   <AppContainer
     onNavigationStateChange={(prevState, currentState, action) => {
-      const currentScreen = getActiveRouteName(currentState);
-      const prevScreen = getActiveRouteName(prevState);
+      const currentRouteName = getActiveRouteName(currentState);
+      const previousRouteName = getActiveRouteName(prevState);
 
-      if (prevScreen !== currentScreen) {
-        // the line below uses the Google Analytics tracker
+      if (previousRouteName !== currentRouteName) {
+        // the line below uses the @react-native-firebase/analytics tracker
         // change the tracker here to use other Mobile analytics SDK.
-        tracker.trackScreenView(currentScreen);
+        analytics().setCurrentScreen(currentRouteName, currentRouteName);
       }
     }}
   />


### PR DESCRIPTION
The repository for `react-native-google-analytics-bridge` has now been archived and users are now recommended to use `@react-native-firebase/analytics`. This commit changes the example to use the more relevant library.