### PR TITLE
Update redux-integration.md

### DIFF
--- a/docs/redux-integration.md
+++ b/docs/redux-integration.md
@@ -24,7 +24,7 @@ export default class App() {
 
 Notice that we wrap our components in a `Provider` like we'd normally do with `react-redux`. Ta da! Now feel free to use `connect` throughout your app.
 
-### Use a component that is `connect`ed in `options`
+### Use a component that is connected in `options`
 
 Create a component, `connect` it to the store, then use that component in the `title`.
 


### PR DESCRIPTION
I think that 'connected' was transformed into `connect`ed.

This might have happened with a search/replace operation on the word "connect", transformed into "`connect`", that would have taken the connected word.

This change was made in : https://github.com/react-navigation/react-navigation.github.io/commit/a0c0567991679b04464a93ed21a12e1a30977705
