### PR TITLE
[V4] fix themes related examples

### DIFF
--- a/website/versioned_docs/version-4.x/themes.md
+++ b/website/versioned_docs/version-4.x/themes.md
@@ -112,6 +112,7 @@ class MyButton extends React.Component {
   static contextType = ThemeContext;
 
   render() {
+    const theme = this.context;
     return (
       <TouchableOpacity
         style={{ backgroundColor: theme === 'light' ? '#000' : '#fff' }}
@@ -341,7 +342,11 @@ Okay, that's a lot of code. There isn't much going on here aside from passing th
 A regrettable limitation of the current implementation of `navigationOptions` is that we are unable to access React context for use in properties such as `headerStyle` and `headerTintColor`. We can and should use them in properties that access React components, for example in `headerRight` we could provide a component like `ThemedHeaderButton`. To apply the theme to other properties we need to use `screenProps`.
 
 ```jsx
-import { createAppContainer, createStackNavigator } from 'react-navigation';
+import { 
+  createAppContainer,
+  createStackNavigator,
+  ThemeContext
+} from 'react-navigation';
 
 class HomeScreen extends React.Component {
   static navigationOptions = ({ screenProps }) => {
@@ -409,6 +414,7 @@ import {
   createStackNavigator,
   createBottomTabNavigator,
   BottomTabBar,
+  ThemeContext
 } from 'react-navigation';
 
 const ThemeConstants = {

--- a/website/versioned_docs/version-4.x/themes.md
+++ b/website/versioned_docs/version-4.x/themes.md
@@ -465,4 +465,4 @@ const Navigation = createAppContainer(Tabs);
 
 You will likely want to go a bit further than we detailed in this guide, such as change the status bar color depending on the theme and customize the border color for the header and tab bar as well. You can see all of the above code plus some more changes to make it more complete in [this Snack](https://snack.expo.io/@react-navigation/themes-example).
 
-I never said it was easy, but this about covers what you need to know to theme an app that uses React Navigation. Good luck, remember me you're a billionaire.
+I never said it was easy, but this about covers what you need to know to be able to theme an app that uses React Navigation. Good luck, remember me when you're a billionaire.


### PR DESCRIPTION
This PR fixes small issues in themes related examples :
* missing `theme` variable initialization in static context usage example
* missing context initialization in _"Themes inside `navigationOptions`"_
* missing `ThemeContext` import in _"Theming tabs and other similar navigators"_