### PR TITLE
[Docs]: Fix Typo in Code Example

### DIFF
--- a/docs/localization.md
+++ b/docs/localization.md
@@ -36,7 +36,7 @@ console.log(Localization.locale);
 Next let's store our `locale` in the state of our root app component and then thread it through `LocalizationContext` to make it available throughout our app.
 
 ```js
-export const LocalizationContext = React,createContext();
+export const LocalizationContext = React.createContext();
 
 export default function App() {
   const [locale, setLocale] = React.useState(Localization.locale);


### PR DESCRIPTION
This PR fixes the following typo: 

Before: 

`export const LocalizationContext = React,createContext();`

After: 

`export const LocalizationContext = React.createContext();`

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `website/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
