### PR TITLE
useNavigation is in '@react-navigation/core' of ver. 'next'

### DIFF
--- a/docs/use-navigation.md
+++ b/docs/use-navigation.md
@@ -13,7 +13,7 @@ sidebar_label: useNavigation
 ```js
 import * as React from 'react';
 import { Button } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/core';
 
 export default function MyBackButton() {
   const navigation = useNavigation();


### PR DESCRIPTION
Otherwise, import from **/native** leads to an error as `useNavigation` there is `undefined`.