### PR TITLE
fix(limitation): added web limitation

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -23,3 +23,5 @@ If you like what React Navigation has to offer but are turned off by this constr
 React Navigation doesn't support master-detail split-views on iPad yet. If you need this feature, you may want to use another library, although you can build it yourself if you like.
 
 React Navigation does not include support for the peek & pop feature available on devices with 3D touch.
+
+React Navigation does not support location change on the web yet. 


### PR DESCRIPTION
Added a small note, because when I've read the README, then the documentation of the library, this is one of the first think I have read. I had to test the whole lib in a sandbox before noticing it actually does not support web location change.

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `website/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
