### PR TITLE
fix: Add react-navigation-stack to expo install command

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,7 +33,7 @@ The libraries we will install now are [`react-native-gesture-handler`](https://g
 In your project directory, run:
 
 ```sh
-expo install react-native-gesture-handler react-native-reanimated react-native-screens react-native-safe-area-context
+expo install react-native-gesture-handler react-native-reanimated react-native-screens react-native-safe-area-context react-navigation-stack
 ```
 
 This will install versions of these libraries that are compatible.

--- a/website/versioned_docs/version-4.x/getting-started.md
+++ b/website/versioned_docs/version-4.x/getting-started.md
@@ -44,7 +44,7 @@ The libraries we will install now are [`react-native-gesture-handler`](https://g
 In your project directory, run:
 
 ```sh
-expo install react-native-gesture-handler react-native-reanimated react-native-screens react-native-safe-area-context
+expo install react-native-gesture-handler react-native-reanimated react-native-screens react-native-safe-area-context react-navigation-stack
 ```
 
 This will install versions of these libraries that are compatible.


### PR DESCRIPTION
Otherwise, this guide doesn't work: https://reactnavigation.org/docs/en/hello-react-navigation.html

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `website/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
