### PR TITLE
chore: add filter language and version on search

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -44,6 +44,9 @@ const siteConfig = {
   algolia: {
     apiKey: 'c967b4a1491b9cb486d3dca087b771e6',
     indexName: 'reactnavigation',
+    algoliaOptions: {
+      facetFilters: [ "language:LANGUAGE", "version:VERSION" ]
+    }
   },
 };
 


### PR DESCRIPTION
When you want to search something on the docs, this may have same results but for different versions, even if you're looking v4 or next version. This PR should handle this situation, if you're looking at v5 the search results will be only for v5 and the language as well. 