### PR TITLE
fix: correct example code for useNavigationState

### DIFF
--- a/docs/use-navigation-state.md
+++ b/docs/use-navigation-state.md
@@ -9,13 +9,13 @@ sidebar_label: useNavigationState
 It takes a selector function as an argument. The selector will receive the full navigation state and can return a specific value from the state:
 
 ```js
-const index = useNavigation(state => state.index);
+const index = useNavigationState(state => state.index);
 ```
 
 The selector function helps to reduce unnecessary re-renders, so your screen will re-render only when that's something you care about. If you actually need the whole state object, you can do this explicitly:
 
 ```js
-const state = useNavigation(state => state);
+const state = useNavigationState(state => state);
 ```
 
 > Note: This hook is useful for advanced cases and it's easy to introduce performance issues if you're not careful. For most of the cases, you don't need the navigator's state.


### PR DESCRIPTION
I was going through the docs for the useNavigationState hook and realized that the example code contained the wrong signature.