### PR TITLE
fix: Clarify initial render analytics screen

### DIFF
--- a/docs/screen-tracking.md
+++ b/docs/screen-tracking.md
@@ -9,7 +9,7 @@ To track the currently active screen, we need to:
 1. Add a callback to get notified of state changes
 2. Get the root navigator state and find the active route name
 
-To get notified of state changes, we can use the `onStateChange` prop on `NavigationNativeContainer`. To get the root navigator state, we can use the `getRootState` method on the container's ref.
+To get notified of state changes, we can use the `onStateChange` prop on `NavigationNativeContainer`. To get the root navigator state, we can use the `getRootState` method on the container's ref. Please note that `onStateChange` is not called on initial render so you have to set your initial screen separately.
 
 ## Example
 


### PR DESCRIPTION
While checking my analytics I noted that my initial screen is not being set.  This has to be done as a separate step which I wanted to clarify.
