### PR TITLE
fix: Import useFocusEffect from core

### DIFF
--- a/docs/navigation-lifecycle.md
+++ b/docs/navigation-lifecycle.md
@@ -81,7 +81,7 @@ Example:
 <samp id="use-focus-effect" />
 
 ```js
-import { useFocusEffect } from '@react-navigation/native';
+import { useFocusEffect } from '@react-navigation/core';
 
 function Profile() {
   useFocusEffect(


### PR DESCRIPTION
useFocusEffect seems to be in @react-navigation/core rather than /native

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `website/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
