### PR TITLE
fix: change .md to.hmtl and add export default to App

### DIFF
--- a/website/versioned_docs/version-4.x/getting-started.md
+++ b/website/versioned_docs/version-4.x/getting-started.md
@@ -7,7 +7,7 @@ original_id: getting-started
 
 React Navigation is born from the React Native community's need for an extensible yet easy-to-use navigation solution written entirely in JavaScript (so you can read and understand all of the source), on top of powerful native primitives.
 
-Before you commit to using React Navigation for your project, you might want to read the [anti-pitch](pitch.md) &mdash; it will help you to understand the tradeoffs that we have chosen along with the areas where we consider the library to be deficient currently.
+Before you commit to using React Navigation for your project, you might want to read the [anti-pitch](pitch.html) &mdash; it will help you to understand the tradeoffs that we have chosen along with the areas where we consider the library to be deficient currently.
 
 ## What to expect
 
@@ -154,4 +154,4 @@ import 'react-native-gesture-handler';
 
 Now you are ready to build and run your app on the device/simulator.
 
-Continue to ["Hello React Navigation"](hello-react-navigation.md) to start writing some code.
+Continue to ["Hello React Navigation"](hello-react-navigation.html) to start writing some code.

--- a/website/versioned_docs/version-4.x/stack-navigator-1.0.md
+++ b/website/versioned_docs/version-4.x/stack-navigator-1.0.md
@@ -9,7 +9,7 @@ Provides a way for your app to transition between screens where each new screen 
 
 By default the stack navigator is configured to have the familiar iOS and Android look & feel: new screens slide in from the right on iOS, fade in from the bottom on Android. On iOS the stack navigator can also be configured to a modal style where screens slide in from the bottom.
 
-To use this navigator, ensure that you have [react-navigation and its dependencies installed](getting-started.md), then install [`react-navigation-stack`](https://github.com/react-navigation/stack/tree/1.0).
+To use this navigator, ensure that you have [react-navigation and its dependencies installed](getting-started.html), then install [`react-navigation-stack`](https://github.com/react-navigation/stack/tree/1.0).
 
 ```sh
 npm install react-navigation-stack@^1.10.3

--- a/website/versioned_docs/version-4.x/stack-navigator.md
+++ b/website/versioned_docs/version-4.x/stack-navigator.md
@@ -9,7 +9,7 @@ Provides a way for your app to transition between screens where each new screen 
 
 By default the stack navigator is configured to have the familiar iOS and Android look & feel: new screens slide in from the right on iOS, fade in from the bottom on Android. On iOS the stack navigator can also be configured to a modal style where screens slide in from the bottom.
 
-To use this navigator, ensure that you have [react-navigation and its dependencies installed](getting-started.md), then install [`react-navigation-stack`](https://github.com/react-navigation/stack).
+To use this navigator, ensure that you have [react-navigation and its dependencies installed](getting-started.html), then install [`react-navigation-stack`](https://github.com/react-navigation/stack).
 
 ```sh
 npm install react-navigation-stack @react-native-community/masked-view

--- a/website/versioned_docs/version-4.x/troubleshooting.md
+++ b/website/versioned_docs/version-4.x/troubleshooting.md
@@ -5,7 +5,7 @@ sidebar_label: Troubleshooting
 original_id: troubleshooting
 ---
 
-This section attempts to outline issues that can happen during setup and may not be related to React Navigation itself. Also see [common mistakes](common-mistakes.md).
+This section attempts to outline issues that can happen during setup and may not be related to React Navigation itself. Also see [common mistakes](common-mistakes.html).
 
 Before troubleshooting an issue, make sure that you have upgraded to **the latest available versions** of the packages. You can install the latest versions by installing the packages again (e.g. `npm install package-name`).
 

--- a/website/versioned_docs/version-5.x/navigation-lifecycle.md
+++ b/website/versioned_docs/version-5.x/navigation-lifecycle.md
@@ -24,24 +24,29 @@ Similar results can be observed (in combination) with other navigators as well. 
 ```jsx
 function App() {
   return (
-    <Tab.Navigator>
-      <Tab.Screen name="First">
-        {() => (
-          <SettingsStack.Navigator>
-            <SettingsStack.Screen name="Settings" component={SettingsScreen} />
-            <SettingsStack.Screen name="Profile" component={ProfileScreen} />
-          </SettingsStack.Navigator>
-        )}
-      </Tab.Screen>
-      <Tab.Screen name="Second">
-        {() => (
-          <HomeStack.Navigator>
-            <HomeStack.Screen name="Home" component={HomeScreen} />
-            <HomeStack.Screen name="Details" component={DetailsScreen} />
-          </HomeStack.Navigator>
-        )}
-      </Tab.Screen>
-    </Tab.Navigator>
+    <NavigationContainer>
+      <Tab.Navigator>
+        <Tab.Screen name="First">
+          {() => (
+            <SettingsStack.Navigator>
+              <SettingsStack.Screen
+                name="Settings"
+                component={SettingsScreen}
+              />
+              <SettingsStack.Screen name="Profile" component={ProfileScreen} />
+            </SettingsStack.Navigator>
+          )}
+        </Tab.Screen>
+        <Tab.Screen name="Second">
+          {() => (
+            <HomeStack.Navigator>
+              <HomeStack.Screen name="Home" component={HomeScreen} />
+              <HomeStack.Screen name="Details" component={DetailsScreen} />
+            </HomeStack.Navigator>
+          )}
+        </Tab.Screen>
+      </Tab.Navigator>
+    </NavigationContainer>
   );
 }
 ```

--- a/website/versioned_docs/version-5.x/navigation-prop.md
+++ b/website/versioned_docs/version-5.x/navigation-prop.md
@@ -137,7 +137,7 @@ Firing the `setParams` action allows a screen to change the params in the route,
 function ProfileScreen({ navigation: { setParams } }) {
   render() {
     return (
-            <Button
+      <Button
         onPress={() =>
           navigation.setParams({
             friends:

--- a/website/versioned_docs/version-5.x/nesting-navigators.md
+++ b/website/versioned_docs/version-5.x/nesting-navigators.md
@@ -19,11 +19,13 @@ function Home() {
 
 function App() {
   return (
-    <Stack.Navigator>
-      <Stack.Screen name="Home" component={Home} />
-      <Stack.Screen name="Profile" component={Profile} />
-      <Stack.Screen name="Settings" component={Settings} />
-    </Stack.Navigator>
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={Home} />
+        <Stack.Screen name="Profile" component={Profile} />
+        <Stack.Screen name="Settings" component={Settings} />
+      </Stack.Navigator>
+    </NavigationContainer>
   );
 }
 ```
@@ -83,10 +85,12 @@ function Root() {
 
 function App() {
   return (
-    <Drawer.Navigator>
-      <Drawer.Screen name="Home" component={Home} />
-      <Drawer.Screen name="Root" component={Root} />
-    </Drawer.Navigator>
+    <NavigationContainer>
+      <Drawer.Navigator>
+        <Drawer.Screen name="Home" component={Home} />
+        <Drawer.Screen name="Root" component={Root} />
+      </Drawer.Navigator>
+    </NavigationContainer>
   );
 }
 ```

--- a/website/versioned_docs/version-5.x/screen-options-resolution.md
+++ b/website/versioned_docs/version-5.x/screen-options-resolution.md
@@ -225,12 +225,14 @@ function HomeTabs() {
 
 const RootStack = createStackNavigator();
 
-function App() {
+export default function App() {
   return (
-    <RootStack.Navigator>
-      <RootStack.Screen name="Home" component={HomeTabs} />
-      <RootStack.Screen name="Settings" component={SettingsScreen} />
-    </RootStack.Navigator>
+    <NavigationContainer>
+      <RootStack.Navigator>
+        <RootStack.Screen name="Home" component={HomeTabs} />
+        <RootStack.Screen name="Settings" component={SettingsScreen} />
+      </RootStack.Navigator>
+    </NavigationContainer>
   );
 }
 ```

--- a/website/versioned_docs/version-5.x/upgrading-from-4.x.md
+++ b/website/versioned_docs/version-5.x/upgrading-from-4.x.md
@@ -183,7 +183,9 @@ function SelectionScreen({ navigation }) {
 
   navigation.setOptions({
     title:
-      selectionCount === 0 ? 'Select items' : `${selectionCount} items selected`,
+      selectionCount === 0
+        ? 'Select items'
+        : `${selectionCount} items selected`,
   });
 
   // ...
@@ -270,18 +272,20 @@ navigation.navigate('App');
 With React Navigation 5.x, we can dynamically define and alter the screen definitions of a navigator, which makes Switch Navigator unnecessary. The above pattern can be now defined declaratively:
 
 ```js
-function App() {
+export default function App() {
   return (
-    <Stack.Navigator>
-      {isLoggedIn ? (
-        <>
-          <Stack.Screen name="Home" component={HomeScreen} />
-          <Stack.Screen name="Settings" component={SettingsScreen} />
-        </>
-      ) : (
-        <Stack.Screen name="SignIn" component={SignInScreen} />
-      )}
-    </Stack.Navigator>
+    <NavigationContainer>
+      <Stack.Navigator>
+        {isLoggedIn ? (
+          <>
+            <Stack.Screen name="Home" component={HomeScreen} />
+            <Stack.Screen name="Settings" component={SettingsScreen} />
+          </>
+        ) : (
+          <Stack.Screen name="SignIn" component={SignInScreen} />
+        )}
+      </Stack.Navigator>
+    </NavigationContainer>
   );
 }
 ```
@@ -340,9 +344,9 @@ In addition, there have been some changes to the way the navigation actions work
 
 One major difference is that a lot of methods used to take some parameters for controlling which screen and navigator it should be applied to and didn't follow a specific pattern.
 
-In this version, we have standardized this and made it possible to use with any action without the action needing to support it. The new  `target` and `source` properties provides control over which navigator should handle an action. See [docs for dispatch](https://reactnavigation.org/docs/navigation-prop.html#dispatch---send-an-action-to-the-router) for more details.
+In this version, we have standardized this and made it possible to use with any action without the action needing to support it. The new `target` and `source` properties provides control over which navigator should handle an action. See [docs for dispatch](https://reactnavigation.org/docs/navigation-prop.html#dispatch---send-an-action-to-the-router) for more details.
 
-You can import the action creators from the [compatibility layer](compatibility.md) to preserve old behavior for the actions.
+You can import the action creators from the [compatibility layer](compatibility.html) to preserve old behavior for the actions.
 
 More differences in the signatures are listed below:
 
@@ -376,7 +380,7 @@ For example, this will reset the navigator's state to have one screen called `Ho
 
 ```js
 navigation.reset({
-  routes: [{ name: 'Home' }]
+  routes: [{ name: 'Home' }],
 });
 ```
 


### PR DESCRIPTION
Changed broken links from `.md` to `.html` and added `<NavigationContainer>` where it was needed