### PR TITLE
docs: useLinking ref is missing

### DIFF
--- a/website/versioned_docs/version-5.x/use-linking.md
+++ b/website/versioned_docs/version-5.x/use-linking.md
@@ -15,6 +15,7 @@ import { ScrollView } from 'react-native';
 import { useLinking } from '@react-navigation/native';
 
 export default function App() {
+  const ref = React.useRef();
   const { getInitialState } = useLinking(ref, {
     prefixes: ['https://mychat.com', 'mychat://'],
     config: {
@@ -42,7 +43,7 @@ export default function App() {
   }
 
   return (
-    <NavigationContainer initialState={initialState}>
+    <NavigationContainer initialState={initialState} ref={ref}>
       {/* content */}
     </NavigationContainer>
   );


### PR DESCRIPTION
In deep-linking documentation, `ref` is declared with `const ref = React.useRef();`
https://reactnavigation.org/docs/en/deep-linking.html 

But in useLinking doc, it's may lacking