### PR TITLE
fix: typo bottom-tabs example

### DIFF
--- a/website/static/examples/5.x/tab-based-navigation-minimal.js
+++ b/website/static/examples/5.x/tab-based-navigation-minimal.js
@@ -21,13 +21,19 @@ function SettingsScreen() {
 
 const Tab = createBottomTabNavigator();
 
+function MyTabs() {
+  return (
+    <Tab.Navigator>
+      <Tab.Screen name="Home" component={HomeScreen} />
+      <Tab.Screen name="Settings" component={SettingsScreen} />
+    </Tab.Navigator>
+  );
+}
+
 export default function App() {
   return (
     <NavigationContainer>
-      <Tab.Navigator>
-        <Tab.Screen name="Home" component={HomeScreen} />
-        <Tab.Screen name="Settings" component={SettingsScreen} />
-      </Tab.Navigator>
+      <MyTabs />
     </NavigationContainer>
   );
 }

--- a/website/versioned_docs/version-5.x/params.md
+++ b/website/versioned_docs/version-5.x/params.md
@@ -66,7 +66,7 @@ function DetailsScreen({ route, navigation }) {
 
 Screens can also update their params, like they can update their state. The `navigation.setParams` method lets you update the params of a screen. Refer to the [API reference for `setParams`](navigation-prop.html#setparams---make-changes-to-route-params) for more details.
 
-You can also pass some initial params to a screen. If you didn't specify any params when navigating to this screen, the initial params will be used. They are also shallow merged with any params that you pass. Initial params can be specified with an `initialparams` prop:
+You can also pass some initial params to a screen. If you didn't specify any params when navigating to this screen, the initial params will be used. They are also shallow merged with any params that you pass. Initial params can be specified with an `initialParams` prop:
 
 ```js
 <Stack.Screen


### PR DESCRIPTION
Fixed a typo and changed the example in bottom-tabs to reflect the docs.