### PR TITLE
add import to 5.x example

### DIFF
--- a/website/versioned_docs/version-5.x/upgrading-from-4.x.md
+++ b/website/versioned_docs/version-5.x/upgrading-from-4.x.md
@@ -73,6 +73,7 @@ The main concepts are the same. There are navigators and screens, nesting works 
 - `defaultNavigationOptions` becomes `screenOptions` prop on `Navigator`
 
 ```js
+import { createStackNavigator } from '@react-navigation/stack';
 const Stack = createStackNavigator();
 
 function RootStack() {


### PR DESCRIPTION
The example in the upgrade guide could more explicitly import the used function. Just trying to make the doc more useful to those performing the upgrade.