### PR TITLE
docs: fix incorrect github link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -94,7 +94,7 @@ module.exports = {
             },
             {
               label: 'GitHub',
-              href: 'https://github.com/facebook/docusaurus',
+              href: 'https://github.com/react-navigation/react-navigation',
             },
             {
               label: 'Twitter',


### PR DESCRIPTION
GitHub link brings me to docusaurus, not react-navigation.

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
