### PR TITLE
fix: delete labelStyle from material-bottom-tabs

### DIFF
--- a/versioned_docs/version-5.x/material-bottom-tab-navigator.md
+++ b/versioned_docs/version-5.x/material-bottom-tab-navigator.md
@@ -198,7 +198,6 @@ function MyTabs() {
     <Tab.Navigator
       initialRouteName="Feed"
       activeColor="#e91e63"
-      labelStyle={{ fontSize: 12 }}
       style={{ backgroundColor: 'tomato' }}
     >
       <Tab.Screen


### PR DESCRIPTION
There is no `labelStyle` prop so it should not be in the example