### PR TITLE
fix: Update navigation-prop.md

### DIFF
--- a/versioned_docs/version-5.x/navigation-prop.md
+++ b/versioned_docs/version-5.x/navigation-prop.md
@@ -8,7 +8,7 @@ Each `screen` component in your app is provided with the `navigation` prop autom
 
 - `navigation`
   - `navigate` - go to another screen, figures out the action it needs to take to do it
-  - `reset` - wipe the navigator state and replace it with the result of several actions
+  - `reset` - wipe the navigator state and replace it with a new routes
   - `goBack` - close active screen and move back in the stack
   - `addListener` - subscribe to updates to navigation lifecycle
   - `setParams` - make changes to route's params


### PR DESCRIPTION
when we want to reset the routes in v5 we give it a new route not several actions that were in v4

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
