### PR TITLE
docs: remove old react-native-screens instructions

### DIFF
--- a/versioned_docs/version-4.x/getting-started.md
+++ b/versioned_docs/version-4.x/getting-started.md
@@ -70,13 +70,6 @@ Next, we need to link these libraries. The steps depends on your React Native ve
   cd ios; pod install; cd ..
   ```
 
-  To finalize installation of `react-native-screens` for Android, add the following two lines to `dependencies` section in `android/app/build.gradle`:
-
-  ```gradle
-  implementation 'androidx.appcompat:appcompat:1.1.0-rc01'
-  implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0-alpha02'
-  ```
-
 - **React Native 0.59 and lower**
 
   If you're on an older React Native version, you need to manually link the dependencies. To do that, run:

--- a/versioned_docs/version-5.x/getting-started.md
+++ b/versioned_docs/version-5.x/getting-started.md
@@ -50,13 +50,6 @@ If you're on a Mac and developing for iOS, you need to install pods to complete 
 cd ios; pod install; cd ..
 ```
 
-To finalize installation of `react-native-screens` for Android, add the following two lines to `dependencies` section in `android/app/build.gradle`:
-
-```gradle
-implementation 'androidx.appcompat:appcompat:1.1.0-rc01'
-implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0-alpha02'
-```
-
 To finalize installation of `react-native-gesture-handler`, add the following at the **top** (make sure it's at the top and there's nothing else before it) of your entry file, such as `index.js` or `App.js`:
 
 ```js


### PR DESCRIPTION
Removed instructions to add two lines to the dependencies section in `android/app/build.gradle` as it is no longer required by `react-native-screens` after [this PR](https://github.com/software-mansion/react-native-screens/pull/397).  

`react-native-screens` removed it from their docs [here](https://github.com/software-mansion/react-native-screens/pull/406).

I removed it from v4 and v5 of the docs.  I didn't see it in any of the other versions. 