### PR TITLE
fix: rewrite nested navigators bubble example

### DIFF
--- a/versioned_docs/version-5.x/nesting-navigators.md
+++ b/versioned_docs/version-5.x/nesting-navigators.md
@@ -50,7 +50,7 @@ For example, when you press the back button inside a nested stack navigator, it'
 
 ### Navigation actions are handled by current navigator and bubble up if couldn't be handled
 
-For example, if you're calling `navigation.goBack()` in a nested screen, it'll only go back in the parent navigator if you're already on the first screen of the navigator. Other actions such as `navigate` work similarly, i.e. navigation will happen in the nested navigator and if the nested navigator couldn't handle it, then the parent navigator will try to handle it. In the above example, when calling `navigate('Settings')`, inside `Profile` screen, the nested stack navigator will handle it, but if you call `navigate('Home')`, the parent tab navigator will handle it.
+For example, if you're calling `navigation.goBack()` in a nested screen, it'll only go back in the parent navigator if you're already on the first screen of the navigator. Other actions such as `navigate` work similarly, i.e. navigation will happen in the nested navigator and if the nested navigator couldn't handle it, then the parent navigator will try to handle it. In the above example, when calling `navigate('Messages')`, inside `Feed` screen, the nested tab navigator will handle it, but if you call `navigate('Settings')`, the parent stack navigator will handle it.
 
 ### Navigator specific methods are available in the navigators nested inside
 


### PR DESCRIPTION
#### Rewritten the nested navigators bubble example

**[Example of nested navigators](https://reactnavigation.org/docs/nesting-navigators/) this PR applies to.**

In the [old example](https://reactnavigation.org/docs/nesting-navigators/#navigation-actions-are-handled-by-current-navigator-and-bubble-up-if-couldnt-be-handled), it is said that if `navigate("Settings")` is called from the `Profile` screen, the nested Stack Navigator will handle it. However, there is no nested navigator for the `Profile` screen in the example. Furthermore, it states that if `navigate("Home")` is called from the `Profile` screen, it will bubble up and the parent Tab Navigator will handle it. There is no parent Tab Navigator, however. Therefore, there will be no bubbling up through the navigators. 

The new example reflects what is actually happening with the nested navigators. If `navigate('Messages')` is called from the `Feed` screen, which is in the same Navigator, the navigate will be handled locally, by the Home component's Tab Navigator.
Calling navigate('Settings') from the Feed screen will then bubble up to the Stack Navigator, since the Home component's Tab Navigator does not have a 'Settings' screen.
