### PR TITLE
Added non-Expo code

### DIFF
--- a/versioned_docs/version-5.x/deep-linking.md
+++ b/versioned_docs/version-5.x/deep-linking.md
@@ -32,7 +32,11 @@ Next, let's configure our navigation container to extract the path from the app'
 ```js
 import { Linking } from 'expo';
 
-const prefix = Linking.makeUrl('/');
+// Expo Version - use the following line if you use Expo managed workflow
+const prefix = Linking.makeUrl('/'); 
+
+// React-Native CLI (non-Expo) Version - Use the following line, instead of the one above, if you are NOT using Expo
+// const prefix = 'casualjob://'; 
 
 function App() {
   const linking = {


### PR DESCRIPTION
Added the following lines: 
// React-Native CLI (non-Expo) Version - Use the following line, instead of the one above, if you are NOT using Expo
// const prefix = 'casualjob://';

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
