### PR TITLE
docs: Update link for headerLeft types

### DIFF
--- a/versioned_docs/version-5.x/stack-navigator.md
+++ b/versioned_docs/version-5.x/stack-navigator.md
@@ -200,7 +200,7 @@ Function which returns a React Element to display on the right side of the heade
 
 #### `headerLeft`
 
-Function which returns a React Element to display on the left side of the header. When a function is used, it receives a number of arguments when rendered (`onPress`, `label`, `labelStyle` and more - check [types.tsx](https://github.com/react-navigation/stack/blob/master/src/types.tsx) for the complete list).
+Function which returns a React Element to display on the left side of the header. When a function is used, it receives a number of arguments when rendered (`onPress`, `label`, `labelStyle` and more - check [types.tsx](https://github.com/react-navigation/react-navigation/blob/master/packages/stack/src/types.tsx#L344-L408) for the complete list).
 
 #### `headerStyle`
 


### PR DESCRIPTION
types.tsx for headerLeft types leads to an archived repository.
Updated the link so that it shows the latest types for headerLeft component

```
# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
```
The change only applies to v5 doc