### PR TITLE
docs: Update navigation prop setOptions example

### DIFF
--- a/versioned_docs/version-5.x/navigation-prop.md
+++ b/versioned_docs/version-5.x/navigation-prop.md
@@ -169,7 +169,7 @@ The `setOptions` method lets us set screen options from within the component. Th
 function ProfileScreen({ navigation, route }) {
   const [value, onChangeText] = React.useState(route.params.title);
 
-  React.useLayoutEffect(() => {
+  React.useEffect(() => {
     navigation.setOptions({
       title: value === '' ? 'No title' : value,
     });


### PR DESCRIPTION
Not entirely sure if this is intended, but I believe in this example use of `React.useLayoutEffect` is misleading.
In the example component no specific DOM manipulations/calculations are made, so `React.useEffect` should be just enough for this case. 

I've tried using `React.useEffect` and it works fine for updating the header title.
