### PR TITLE
Add information about HeaderBackButton

### DIFF
--- a/versioned_docs/version-5.x/header-buttons.md
+++ b/versioned_docs/version-5.x/header-buttons.md
@@ -87,6 +87,8 @@ The back button will be rendered automatically in a stack navigator whenever it 
 
 Generally, this is what you want. But it's possible that in some circumstances that you want to customize the back button more than you can through the options mentioned above, in which case you can set the `headerLeft` option to a React Element that will be rendered, just as we did with `headerRight`. Alternatively, the `headerLeft` option also accepts a React Component, which can be used, for example, for overriding the onPress behavior of the back button. Read more about this in the [api reference](/docs/stack-navigator/#headerleft).
 
+If you would like to retain the view of back button and only override the `onPress` method, you can import [HeaderBackButton](https://github.com/react-navigation/react-navigation/blob/master/packages/stack/src/views/Header/HeaderBackButton.tsx) from `@react-navigation/stack` and assign that component to the `headerLeft` option.
+
 ## Summary
 
 - You can set buttons in the header through the `headerLeft` and `headerRight` properties in `options`.

--- a/versioned_docs/version-5.x/header-buttons.md
+++ b/versioned_docs/version-5.x/header-buttons.md
@@ -87,7 +87,7 @@ The back button will be rendered automatically in a stack navigator whenever it 
 
 Generally, this is what you want. But it's possible that in some circumstances that you want to customize the back button more than you can through the options mentioned above, in which case you can set the `headerLeft` option to a React Element that will be rendered, just as we did with `headerRight`. Alternatively, the `headerLeft` option also accepts a React Component, which can be used, for example, for overriding the onPress behavior of the back button. Read more about this in the [api reference](/docs/stack-navigator/#headerleft).
 
-If you would like to retain the view of back button and only override the `onPress` method, you can import [HeaderBackButton](https://github.com/react-navigation/react-navigation/blob/master/packages/stack/src/views/Header/HeaderBackButton.tsx) from `@react-navigation/stack` and assign that component to the `headerLeft` option.
+If you would like to retain the view of back button and only override the `onPress` method, you can import [HeaderBackButton](https://github.com/react-navigation/react-navigation/blob/main/packages/stack/src/views/Header/HeaderBackButton.tsx) from `@react-navigation/stack` and assign that component to the `headerLeft` option.
 
 ## Summary
 


### PR DESCRIPTION
I've ran into a scene where I'd like to override the onPress of back button without changing its looks.
I've searched and found that you can import `HeaderBackButton` component, but I couldn't find that being mentioned in the document, so I'm adding information for other people who runs into same problem.

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
