### PR TITLE
minor typo fix in auth-flow

### DIFF
--- a/versioned_docs/version-5.x/auth-flow.md
+++ b/versioned_docs/version-5.x/auth-flow.md
@@ -88,7 +88,7 @@ return (
 );
 ```
 
-In the above snippet, `isLoading` means that we're still checking if we have a token. This can usually be done by checking if we have a token in `AsyncStorage` and validating if token. After we get the token and if it's valid, we need to set the `userToken`. We also have another state called `isSignout` to have a different animation on sign out.
+In the above snippet, `isLoading` means that we're still checking if we have a token. This can usually be done by checking if we have a token in `AsyncStorage` and validating the token. After we get the token and if it's valid, we need to set the `userToken`. We also have another state called `isSignout` to have a different animation on sign out.
 
 The main thing to notice is that we're conditionally defining screens based on these state variables:
 


### PR DESCRIPTION
The sentence "This can usually be done by checking if we have a token in `AsyncStorage` and validating if token" is a bit confusing. Specifically "validating if token". I believe it's implied that we check if the token exists and validate it.

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
