### PR TITLE
Fix typo on configuring-links

### DIFF
--- a/versioned_docs/version-5.x/configuring-links.md
+++ b/versioned_docs/version-5.x/configuring-links.md
@@ -85,7 +85,7 @@ const linking = {
 };
 ```
 
-Here `Chat` is the name of the screen that handles the URL `/feed`, and `Profile` handles the URL `/profile`.
+Here `Chat` is the name of the screen that handles the URL `/feed`, and `Profile` handles the URL `/user`.
 
 ## Passing params
 


### PR DESCRIPTION
closes https://github.com/react-navigation/react-navigation.github.io/issues/766