### PR TITLE
fix: Update gestureResponseDistance horizontal default in docs

### DIFF
--- a/versioned_docs/version-5.x/stack-navigator.md
+++ b/versioned_docs/version-5.x/stack-navigator.md
@@ -340,7 +340,7 @@ Gestures are not supported on Web.
 
 Object to override the distance of touch start from the edge of the screen to recognize gestures. The object can contain the following properties:
 
-- `horizontal` - _number_ - Distance for horizontal direction. Defaults to 25.
+- `horizontal` - _number_ - Distance for horizontal direction. Defaults to 50.
 - `vertical` - _number_ - Distance for vertical direction. Defaults to 135.
 
 This is not supported on Web.


### PR DESCRIPTION
[According to the source code](https://github.com/react-navigation/react-navigation/blob/0a19e94b23a4d2b5f22d1d9deb0544f586f475ee/packages/stack/src/views/Stack/Card.tsx#L75), this default appears to be `50`

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
