### PR TITLE
fix: typo in hiding-tabbar-in-screens

### DIFF
--- a/versioned_docs/version-5.x/hiding-tabbar-in-screens.md
+++ b/versioned_docs/version-5.x/hiding-tabbar-in-screens.md
@@ -28,7 +28,7 @@ function App() {
 }
 ```
 
-With this structure, when we navigate to the `Profile` or `Settings` screen, the tab bar is still stay visible over those screens.
+With this structure, when we navigate to the `Profile` or `Settings` screen, the tab bar will still stay visible over those screens.
 
 But if we want to show the tab bar only on the `Home`, `Feed` and `Notifications` screens, but not on the `Profile` and `Settings` screens, we'll need to change the navigation structure. The easiest way to achieve this is to nest the tab navigator inside the first screen of the stack instead of nesting stack inside tab navigator:
 


### PR DESCRIPTION
"...the tab bar **is** still stay visible over those..." should read "...the tab bar **will** still stay visible over those..."