### PR TITLE
Missing import in state-persistence example

### DIFF
--- a/versioned_docs/version-5.x/state-persistence.md
+++ b/versioned_docs/version-5.x/state-persistence.md
@@ -21,7 +21,7 @@ To be able to persist the navigation state, we can use the `onStateChange` and `
 
 ```js
 import * as React from 'react';
-import { Linking } from 'react-native';
+import { Linking, Platform } from 'react-native';
 import AsyncStorage from '@react-native-community/async-storage';
 import { NavigationContainer } from '@react-navigation/native';
 


### PR DESCRIPTION
`Platform` was not imported in state-persistence example

I think this only applies to the docs for version 5 — not actually clear what the below is telling me to do; is there another place I should also edit?

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
