### PR TITLE
Fix docs for InitialParams

### DIFF
--- a/versioned_docs/version-5.x/upgrading-from-4.x.md
+++ b/versioned_docs/version-5.x/upgrading-from-4.x.md
@@ -113,7 +113,7 @@ This means, now we can access screen's params through `route.params` instead of 
 
 ```js
 function ProfileScreen({ route }) {
-  const userId = route.params.me;
+  const userId = route.params.user;
 
   // ...
 }


### PR DESCRIPTION
It should be 'route.params.user' instead of route.params.me in the session The navigation prop ( https://reactnavigation.org/docs/upgrading-from-4.x/ 

Before:
![stack](https://user-images.githubusercontent.com/42044496/85643290-13036680-b66a-11ea-838c-e7726dad60a8.png)
![function](https://user-images.githubusercontent.com/42044496/85643292-139bfd00-b66a-11ea-88a0-415109cc9c75.png)

Now:
![now](https://user-images.githubusercontent.com/42044496/85643355-3c23f700-b66a-11ea-99b3-ae4e6674065e.png)

