### PR TITLE
Removed incompatible navigator resources

### DIFF
--- a/versioned_docs/version-5.x/community-libraries-and-navigators.md
+++ b/versioned_docs/version-5.x/community-libraries-and-navigators.md
@@ -6,20 +6,6 @@ sidebar_label: Community Navigators and Libraries
 
 > Libraries listed in this guide may not have been updated to work with the latest version of React Navigation. Please refer to the library's documentation to see which version of React Navigation it supports.
 
-# Navigators
-
-## Fluid Transitions
-
-Fluid Transitions is a library that provides Shared Element Transitions during navigation between screens using react-navigation.
-
-A Shared Element Transition is the visualization of an element in one screen being transformed into a corresponding element in another screen during the navigation transition.
-
-The library implements a custom navigator called `FluidNavigator` that makes all this and more possible.
-
-#### Links
-
-[github.com/fram-x/FluidTransitions](https://github.com/fram-x/FluidTransitions)
-
 # Libraries
 
 ## react-navigation-collapsible


### PR DESCRIPTION
since react-native-fluid-transitions doesn't support react-navigation v5

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
