### PR TITLE
add import to 5.x example

### DIFF
--- a/versioned_docs/version-5.x/upgrading-from-4.x.md
+++ b/versioned_docs/version-5.x/upgrading-from-4.x.md
@@ -80,6 +80,7 @@ The main concepts are the same. There are navigators and screens, nesting works 
 - `defaultNavigationOptions` becomes `screenOptions` prop on `Navigator`
 
 ```js
+import { createStackNavigator } from '@react-navigation/stack';
 const Stack = createStackNavigator();
 
 function RootStack() {


### PR DESCRIPTION
rebase of https://github.com/react-navigation/react-navigation.github.io/pull/680

there is no 3.x version of this document, so no versioned doc changes needed here.