### PR TITLE
Added a note for changes in usage of header

### DIFF
--- a/versioned_docs/version-5.x/upgrading-from-4.x.md
+++ b/versioned_docs/version-5.x/upgrading-from-4.x.md
@@ -486,3 +486,19 @@ We also have documentation on how to use the new hooks such as [`useFocusEffect`
 We have long recommended not to store navigation state in Redux. We have finally dropped support for storing navigation state in Redux in React Navigation 5.x.
 
 This means you cannot store navigation state in Redux. You can still use Redux (or any other library) for managing your app state and it will work fine. See [Redux integration](redux-integration.md) for more info.
+
+## Options for screens inside of a navigator
+
+### `header`
+
+Previously to hide the header we used to specify it as
+
+```js
+header: null
+```
+Now in 5.x it should be a function that returns an empty component as follows:
+
+```js
+header: () => {}
+```
+


### PR DESCRIPTION
Added a note for changes in usage of header where header specifying as null in v5 leading to crashes. And this crashes got fixed by specifying the header as a function that returns an empty component

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
