### PR TITLE
Removed extra bracket from code snippet

### DIFF
--- a/versioned_docs/version-5.x/deep-linking.md
+++ b/versioned_docs/version-5.x/deep-linking.md
@@ -57,7 +57,7 @@ If you are using universal links, you need to add your domain to the prefixes.
 function App() {
   const linking = {
     prefixes: ['https://app.example.com'],
-  });
+  };
 
   return (
     <NavigationContainer linking={linking} fallback={<Text>Loading...</Text>}>


### PR DESCRIPTION
I fixed a typo in the code snippet that had an extra closing bracket for better copying and pasting experience.
