### PR TITLE
docs: Update 'Passing params to a previous screen'

### DIFF
--- a/versioned_docs/version-5.x/params.md
+++ b/versioned_docs/version-5.x/params.md
@@ -146,6 +146,32 @@ navigation.navigate('Account', {
 
 See [Nesting navigators](nesting-navigators.md) for more details on nesting.
 
+## Behavior of params
+
+On every action (e.g. ```navigation```, ```setParams```, etc.) params are getting merged. 
+If your previous screen already contains route params, new params will added or overwrite current.
+
+```
+// old params
+{
+  user: 'jane',
+  age: 20
+}
+
+// new params
+{
+  age: 33,
+  position: 'developer'
+}
+
+// result
+{
+  user: 'jane',
+  age: 33,
+  position: 'developer'
+}
+```
+
 ## Summary
 
 - `navigate` and `push` accept an optional second argument to let you pass parameters to the route you are navigating to. For example: `navigation.navigate('RouteName', {paramName: 'value'})`.

--- a/versioned_docs/version-5.x/params.md
+++ b/versioned_docs/version-5.x/params.md
@@ -81,8 +81,6 @@ You can also pass some initial params to a screen. If you didn't specify any par
 
 Params aren't only useful for passing some data to a new screen, but they can also be useful to pass data to a previous screen too. For example, let's say you have a screen with a create post button, and the create post button opens a new screen to create a post. After creating the post, you want to pass the data for the post back to previous screen.
 
-If your previous screen already contains route params, new params will be merged. This behaviour is the same as in ```setParams``` action.
-
 To achieve this, you can use the `navigate` method, which acts like `goBack` if the screen already exists. You can pass the `params` with `navigate` to pass the data back:
 
 <samp id="passing-params-back" />

--- a/versioned_docs/version-5.x/params.md
+++ b/versioned_docs/version-5.x/params.md
@@ -81,6 +81,8 @@ You can also pass some initial params to a screen. If you didn't specify any par
 
 Params aren't only useful for passing some data to a new screen, but they can also be useful to pass data to a previous screen too. For example, let's say you have a screen with a create post button, and the create post button opens a new screen to create a post. After creating the post, you want to pass the data for the post back to previous screen.
 
+If your previous screen already contains route params, new params will be merged. This behaviour is the same as in ```setParams``` action.
+
 To achieve this, you can use the `navigate` method, which acts like `goBack` if the screen already exists. You can pass the `params` with `navigate` to pass the data back:
 
 <samp id="passing-params-back" />


### PR DESCRIPTION
I'm currently developing app that passes params from subsequent screens. One screen also has a screen that passes back additional route params.
I was not sure if I needed to pass all params to new screen or if the behaviour is the same as ```setParams```.
It turns out that second behaviour is present. 
I think it will be useful to mention it in the documentation.