### PR TITLE
docs: Update link to edit docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -145,7 +145,7 @@ module.exports = {
           docLayoutComponent: require.resolve('./src/layouts/DocPage.js'),
           docItemComponent: require.resolve('./src/layouts/DocItem.js'),
           editUrl:
-            'https://github.com/react-navigation/react-navigation.github.io/edit/source/',
+            'https://github.com/react-navigation/react-navigation.github.io/edit/main/',
           remarkPlugins: [require('./src/plugins/remark-npm2yarn')],
         },
         theme: {


### PR DESCRIPTION
Current link is outdated and redirects to 404 page
E.g. https://github.com/react-navigation/react-navigation.github.io/edit/source/versioned_docs/version-5.x/navigation-actions.md