### PR TITLE
docs: changed return type of useEffect()

### DIFF
--- a/versioned_docs/version-5.x/navigating-without-navigation-prop.md
+++ b/versioned_docs/version-5.x/navigating-without-navigation-prop.md
@@ -87,7 +87,9 @@ import { navigationRef, isReadyRef } from './RootNavigation';
 
 export default function App() {
   React.useEffect(() => {
-    return () => (isReadyRef.current = false);
+    return () => {
+      isReadyRef.current = false
+    };
   }, []);
 
   return (


### PR DESCRIPTION
Hi,

thanks for creating and maintaining such a great lib.

I stumbled upon a typo in the docs for V5. The return type for an arrow function within an useEffect should return an object instead of a boolean. This way TypeScript won't complain about a return type other than void.

This is for version 5 of react-navigation only and therefore only changed in the corresponding versioned_docs.
