### PR TITLE
docs: Add minimum version to preventing-going-back doc

### DIFF
--- a/versioned_docs/version-5.x/navigation-events.md
+++ b/versioned_docs/version-5.x/navigation-events.md
@@ -10,7 +10,7 @@ Following are the built-in events available with every navigator:
 
 - `focus` - This event is emitted when the screen comes into focus
 - `blur` - This event is emitted when the screen goes out of focus
-- `beforeRemove` - This event is emitted when the user is a leaving the screen, there's a chance of [preventing the user from leaving](preventing-going-back.md)
+- `beforeRemove` (version 5.7+ only) - This event is emitted when the user is a leaving the screen, there's a chance of [preventing the user from leaving](preventing-going-back.md)
 - `state` (advanced) - This event is emitted when the navigator's state changes
 
 Apart from these, each navigator can emit their own custom events. For example, stack navigator emits `transitionStart` and `transitionEnd` events, tab navigator emits `tabPress` event etc. You can find details about the events emitted on the individual navigator's documentation.

--- a/versioned_docs/version-5.x/preventing-going-back.md
+++ b/versioned_docs/version-5.x/preventing-going-back.md
@@ -4,6 +4,8 @@ title: Preventing going back
 sidebar_label: Preventing going back
 ---
 
+**Available in version 5.7+**
+
 Sometimes you may want to prevent the user from leaving a screen, for example, if there are unsaved changes, you might want to show a confirmation dialog.
 
 You can achieve it by using the `beforeRemove` event. This event is triggered whenever a screen is being removed. For example:


### PR DESCRIPTION
The label at the top of this doc says v5.x, but it is only available in v5.7+
![image](https://user-images.githubusercontent.com/13405567/89941910-b04e3600-dbe9-11ea-8fc4-cd08bf32d1a1.png)

Reference: https://github.com/react-navigation/react-navigation/pull/8530#issuecomment-658158716

