### PR TITLE
Update modal.md

### DIFF
--- a/versioned_docs/version-5.x/modal.md
+++ b/versioned_docs/version-5.x/modal.md
@@ -62,11 +62,10 @@ function MainStackScreen() {
 
 function RootStackScreen() {
   return (
-    <RootStack.Navigator mode="modal">
+    <RootStack.Navigator mode="modal" headerMode="none">
       <RootStack.Screen
         name="Main"
         component={MainStackScreen}
-        options={{ headerShown: false }}
       />
       <RootStack.Screen name="MyModal" component={ModalScreen} />
     </RootStack.Navigator>


### PR DESCRIPTION
The example shown in the documentation was wrong. The parent stack navigator needs to have its `headerMode` prop set to `none`. The `headerShown` option is irrelevant for this example.

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
