### PR TITLE
Replace DrawerItems with DrawerNavigationItems for 4.x

### DIFF
--- a/versioned_docs/version-4.x/drawer-navigator.md
+++ b/versioned_docs/version-4.x/drawer-navigator.md
@@ -42,7 +42,7 @@ The route configs object is a mapping from route name to a route config, which t
 - `gestureHandlerProps` - Props to pass to the underlying pan gesture handler.
 - `lazy` - Whether the screens should render the first time they are accessed. Defaults to `true`. Set it to `false` if you want to render all screens on initial render.
 - `unmountInactiveRoutes` - Whether a screen should be unmounted when navigating away from it. Defaults to `false`.
-- `contentComponent` - Component used to render the content of the drawer, for example, navigation items. Receives the `navigation` prop and `drawerOpenProgress` for the drawer. Defaults to `DrawerItems`. For more information, see below.
+- `contentComponent` - Component used to render the content of the drawer, for example, navigation items. Receives the `navigation` prop and `drawerOpenProgress` for the drawer. Defaults to `DrawerNavigationItems`. For more information, see below.
 - `contentOptions` - Configure the drawer content, see below.
 - `navigationOptions` - Navigation options for the navigator itself, to configure a parent navigator
 - `defaultNavigationOptions` - Default navigation options to use for screens
@@ -60,7 +60,7 @@ The default component for the drawer is scrollable and only contains links for t
 
 ```js
 import SafeAreaView from 'react-native-safe-area-view';
-import { DrawerItems } from 'react-navigation-drawer';
+import { DrawerNavigationItems } from 'react-navigation-drawer';
 
 const CustomDrawerContentComponent = props => (
   <ScrollView>
@@ -68,7 +68,7 @@ const CustomDrawerContentComponent = props => (
       style={styles.container}
       forceInset={{ top: 'always', horizontal: 'never' }}
     >
-      <DrawerItems {...props} />
+      <DrawerNavigationItems {...props} />
     </SafeAreaView>
   </ScrollView>
 );


### PR DESCRIPTION
When upgrading from 3.x to 4.x, I updated the packages and imports per https://reactnavigation.org/docs/4.x/upgrading-from-3.x/ and everything worked except the drawer nav. When I used `DrawerItems`, I got an error:
```
Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.
```

My suggested change fixed my little Drawer Navigator. I think maybe this component was renamed in `react-navigation-drawer` 1.4.0, which is the version the migration guide recommends for 4.x.

This might be the wrong change. I saw the 2.4.0 [changelog](https://github.com/react-navigation/react-navigation/blob/4.x/packages/drawer/CHANGELOG.md#240-2020-02-24) mentions DrawerItems is re-exposed. In that case, perhaps the migration guide should be updated to recommend installing this newer version?

I lost motivation tracing the source with repos moving around, but hopefully this PR is somewhat helpful.

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
