### PR TITLE
remove deprecated react-native-header-scroll-view

### DIFF
--- a/versioned_docs/version-5.x/community-libraries-and-navigators.md
+++ b/versioned_docs/version-5.x/community-libraries-and-navigators.md
@@ -68,9 +68,3 @@ Easily handle Android back button behavior with React-Navigation with a componen
 
 [github.com/vonovak/react-navigation-backhandler](https://github.com/vonovak/react-navigation-backhandler)
 
-
-#### Links
-
-[https://github.com/jonsamp/react-native-header-scroll-view](https://github.com/jonsamp/react-native-header-scroll-view)
-
-[Demo on expo via VaxNow](https://expo.io/@thomaswangio/vax-now)


### PR DESCRIPTION
This small PR removes the link to the deprecated and unmaintained [`react-native-header-scroll-view`](https://github.com/jonsamp/react-native-header-scroll-view) library and the related example link, which also leads to 404.