### PR TITLE
Update getting started to note about Windows

### DIFF
--- a/versioned_docs/version-5.x/getting-started.md
+++ b/versioned_docs/version-5.x/getting-started.md
@@ -51,7 +51,7 @@ npm install react-native-reanimated react-native-gesture-handler react-native-sc
 
 > Note: You might get warnings related to peer dependencies after installation. They are usually caused by incorrect version ranges specified in some packages. You can safely ignore most warnings as long as your app builds.
 
-> Note: If using this project with [react-native-windows](https://github.com/microsoft/react-native-windows), omit`react-native-gesture-handler`.
+> Note: If using this project with [react-native-windows](https://github.com/microsoft/react-native-windows), omit `react-native-gesture-handler`.
 
 From React Native 0.60 and higher, [linking is automatic](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md). So you **don't need to run** `react-native link`.
 
@@ -67,7 +67,7 @@ To finalize installation of `react-native-gesture-handler`, add the following at
 import 'react-native-gesture-handler';
 ```
 
-> Note: Unless you are using react-native-windows, do not skip this step as your app may crash in production even if it works fine in development.
+> Note: If you are building for Android or iOS, do not skip this step, or your app may crash in production even if it works fine in development. This is not applicable to other platforms.
 
 Now, we need to wrap the whole app in `NavigationContainer`. Usually you'd do this in your entry file, such as `index.js` or `App.js`:
 

--- a/versioned_docs/version-5.x/getting-started.md
+++ b/versioned_docs/version-5.x/getting-started.md
@@ -51,6 +51,8 @@ npm install react-native-reanimated react-native-gesture-handler react-native-sc
 
 > Note: You might get warnings related to peer dependencies after installation. They are usually caused by incorrect version ranges specified in some packages. You can safely ignore most warnings as long as your app builds.
 
+> Note: If using this project with [react-native-windows](https://github.com/microsoft/react-native-windows), omit`react-native-gesture-handler`.
+
 From React Native 0.60 and higher, [linking is automatic](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md). So you **don't need to run** `react-native link`.
 
 If you're on a Mac and developing for iOS, you need to install the pods (via [Cocoapods](https://cocoapods.org/)) to complete the linking.
@@ -65,7 +67,7 @@ To finalize installation of `react-native-gesture-handler`, add the following at
 import 'react-native-gesture-handler';
 ```
 
-> Note: If you skip this step, your app may crash in production even if it works fine in development.
+> Note: Unless you are using react-native-windows, do not skip this step as your app may crash in production even if it works fine in development.
 
 Now, we need to wrap the whole app in `NavigationContainer`. Usually you'd do this in your entry file, such as `index.js` or `App.js`:
 


### PR DESCRIPTION
Now that react-native windows supports react-navigation, I've added a couple of notes in the getting started page due to the fact that react-native-gesture-handler breaks the app on Windows and prevents a successful build.