### PR TITLE
fix: mention useCallback to passing additional props

### DIFF
--- a/versioned_docs/version-5.x/hello-react-navigation.md
+++ b/versioned_docs/version-5.x/hello-react-navigation.md
@@ -133,7 +133,7 @@ Sometimes we might want to pass additional props to a screen. We can do that wit
    </Stack.Screen>
    ```
 
-> Note: By default, React Navigation applies optimizations to screen components to prevent unnecessary renders. Using a render callback removes those optimizations. So if you use a render callback, you'll need to ensure that you use [`React.memo`](https://reactjs.org/docs/react-api.html#reactmemo) or [`React.PureComponent`](https://reactjs.org/docs/react-api.html#reactpurecomponent) for your screen components to avoid performance issues.
+> Note: By default, React Navigation applies optimizations to screen components to prevent unnecessary renders. Using a render callback removes those optimizations. So if you use a render callback, you'll need to ensure that you use [`React.memo`](https://reactjs.org/docs/react-api.html#reactmemo) or [`React.PureComponent`](https://reactjs.org/docs/react-api.html#reactpurecomponent) for your screen components or [`React.useCallback`](https://reactjs.org/docs/hooks-reference.html#usecallback) for your inline function to avoid performance issues.
 
 ## What's next?
 


### PR DESCRIPTION
As the children prop is a function, it seems like using `useCallback` is more appropriate.

Example:
```js
import React, {useCallback} from 'react';

function App() {
const [counter, setCounter] = useState(0);

const renderScreen = useCallback(({router, navigation}) => {
  return <HomeScreen  router={router} navigation={navigation} counter={counter} />
}, [counter])

  return <Stack.Navigator>
    <Stack.Screen name="Home">
      {renderScreen}
    </Stack.Screen>
 </Stack.Navigator>
}
```

With `useMemo` or `PureComponent`, I'm a lever deeper (rendering the component), so I would need to handle not only my custom props, but `router`, `navigation`, ... props coming from React Navigation.

With `useCallback`, I just need to pass my additional props!

ref: https://reactjs.org/docs/hooks-reference.html#usecallback

If you agree with this, I could **replace** `useMemo` and `PureComponent` with `useCallback` and class methods and probably add an example.
I'll would that for all docs versions then
