### PR TITLE
docs: remove deprecated accessibilityStates prop

### DIFF
--- a/static/examples/5.x/custom-tab-bar.js
+++ b/static/examples/5.x/custom-tab-bar.js
@@ -76,7 +76,7 @@ const Tab = createBottomTabNavigator();
 export default function App() {
   return (
     <NavigationContainer>
-      <Tab.Navigator tabBar={(props) => <MyTabBar {...props} />}>
+      <Tab.Navigator tabBar={props => <MyTabBar {...props} />}>
         <Tab.Screen name="Home" component={HomeScreen} />
         <Tab.Screen name="Settings" component={SettingsScreen} />
       </Tab.Navigator>

--- a/static/examples/5.x/custom-tab-bar.js
+++ b/static/examples/5.x/custom-tab-bar.js
@@ -54,7 +54,7 @@ function MyTabBar({ state, descriptors, navigation }) {
         return (
           <TouchableOpacity
             accessibilityRole="button"
-            accessibilityStates={isFocused ? ['selected'] : []}
+            accessibilityState={isFocused ? { selected: true } : {}}
             accessibilityLabel={options.tabBarAccessibilityLabel}
             testID={options.tabBarTestID}
             onPress={onPress}
@@ -76,7 +76,7 @@ const Tab = createBottomTabNavigator();
 export default function App() {
   return (
     <NavigationContainer>
-      <Tab.Navigator tabBar={props => <MyTabBar {...props} />}>
+      <Tab.Navigator tabBar={(props) => <MyTabBar {...props} />}>
         <Tab.Screen name="Home" component={HomeScreen} />
         <Tab.Screen name="Settings" component={SettingsScreen} />
       </Tab.Navigator>

--- a/static/examples/5.x/material-top-tab-custom-tab-bar.js
+++ b/static/examples/5.x/material-top-tab-custom-tab-bar.js
@@ -39,13 +39,13 @@ function MyTabBar({ state, descriptors, navigation, position }) {
         const inputRange = state.routes.map((_, i) => i);
         const opacity = Animated.interpolate(position, {
           inputRange,
-          outputRange: inputRange.map(i => (i === index ? 1 : 0)),
+          outputRange: inputRange.map((i) => (i === index ? 1 : 0)),
         });
 
         return (
           <TouchableOpacity
             accessibilityRole="button"
-            accessibilityStates={isFocused ? ['selected'] : []}
+            accessibilityState={isFocused ? { selected: true } : {}}
             accessibilityLabel={options.tabBarAccessibilityLabel}
             testID={options.tabBarTestID}
             onPress={onPress}
@@ -89,7 +89,7 @@ const Tab = createMaterialTopTabNavigator();
 export default function App() {
   return (
     <NavigationContainer>
-      <Tab.Navigator tabBar={props => <MyTabBar {...props} />}>
+      <Tab.Navigator tabBar={(props) => <MyTabBar {...props} />}>
         <Tab.Screen name="Home" component={HomeScreen} />
         <Tab.Screen name="Settings" component={SettingsScreen} />
         <Tab.Screen name="Profile" component={ProfileScreen} />

--- a/static/examples/5.x/material-top-tab-custom-tab-bar.js
+++ b/static/examples/5.x/material-top-tab-custom-tab-bar.js
@@ -39,7 +39,7 @@ function MyTabBar({ state, descriptors, navigation, position }) {
         const inputRange = state.routes.map((_, i) => i);
         const opacity = Animated.interpolate(position, {
           inputRange,
-          outputRange: inputRange.map((i) => (i === index ? 1 : 0)),
+          outputRange: inputRange.map(i => (i === index ? 1 : 0)),
         });
 
         return (

--- a/static/examples/5.x/material-top-tab-custom-tab-bar.js
+++ b/static/examples/5.x/material-top-tab-custom-tab-bar.js
@@ -89,7 +89,7 @@ const Tab = createMaterialTopTabNavigator();
 export default function App() {
   return (
     <NavigationContainer>
-      <Tab.Navigator tabBar={(props) => <MyTabBar {...props} />}>
+      <Tab.Navigator tabBar={props => <MyTabBar {...props} />}>
         <Tab.Screen name="Home" component={HomeScreen} />
         <Tab.Screen name="Settings" component={SettingsScreen} />
         <Tab.Screen name="Profile" component={ProfileScreen} />

--- a/versioned_docs/version-5.x/bottom-tab-navigator.md
+++ b/versioned_docs/version-5.x/bottom-tab-navigator.md
@@ -119,7 +119,7 @@ function MyTabBar({ state, descriptors, navigation }) {
         return (
           <TouchableOpacity
             accessibilityRole="button"
-            accessibilityStates={isFocused ? ['selected'] : []}
+            accessibilityState={isFocused ? { selected: true } : {}}
             accessibilityLabel={options.tabBarAccessibilityLabel}
             testID={options.tabBarTestID}
             onPress={onPress}

--- a/versioned_docs/version-5.x/material-top-tab-navigator.md
+++ b/versioned_docs/version-5.x/material-top-tab-navigator.md
@@ -229,7 +229,7 @@ function MyTabBar({ state, descriptors, navigation, position }) {
         return (
           <TouchableOpacity
             accessibilityRole="button"
-            accessibilityStates={isFocused ? ['selected'] : []}
+            accessibilityState={isFocused ? { selected: true } : {}}
             accessibilityLabel={options.tabBarAccessibilityLabel}
             testID={options.tabBarTestID}
             onPress={onPress}


### PR DESCRIPTION
# READ ME PLEASE!

Changed `accessibilityStates` prop to `accessibilityState`, as `accessibilityStates` prop is no longer being used in react-native

ref: https://github.com/facebook/react-native/pull/26168

```
Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
```

I've looked at version-3.x docs and the changed content did not exist in the older docs.


