### PR TITLE
Update Reactiflux invite URL

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -77,7 +77,7 @@ module.exports = {
           items: [
             {
               label: 'Chat in our Discord channel',
-              href: 'https://discord.gg/4xEK3nD',
+              href: 'https://discord.gg/reactiflux',
             },
             {
               label: 'Get help on Stack Overflow',

--- a/src/pages/help.js
+++ b/src/pages/help.js
@@ -14,7 +14,7 @@ export default function Help () {
       title: <p>Browse Docs and API</p>,
     },
     {
-      content: <p>Ask questions about the documentation and project in the `#react-navigation` channel on the <Link to={useBaseUrl('https://discord.gg/4xEK3nD')}> Reactiflux Discord</Link>.</p>,
+      content: <p>Ask questions about the documentation and project in the `#react-navigation` channel on the <Link to={useBaseUrl('https://discord.gg/reactiflux')}> Reactiflux Discord</Link>.</p>,
       title: <p>Join the community</p>,
     },
     {


### PR DESCRIPTION
The old invite was putting joiners into an error state due to the new Code of Conduct gate! They'd see a "messages failed to load" error, and they'd need to navigate to #welcome first to accept. Not ideal.