### PR TITLE
Update material-bottom-tab-navigator.md

### DIFF
--- a/versioned_docs/version-5.x/material-bottom-tab-navigator.md
+++ b/versioned_docs/version-5.x/material-bottom-tab-navigator.md
@@ -121,7 +121,7 @@ Color for the tab bar when the tab corresponding to the screen is active. Used f
 
 #### `tabBarLabel`
 
-Title string of a tab displayed in the tab bar. When undefined, scene `title` is used. To hide, see `labeled` option in the previous section.
+Title string of a tab displayed in the tab bar. When undefined, scene `title` is used. To hide, see `labeled` option in the previous section. You can also pass a React Component for full customization.
 
 #### `tabBarBadge`
 


### PR DESCRIPTION
The `theme` prop doesn't have any effect on this component's tab bar label font as it does react-native-paper's `BottomNavigation` component, so after digging through the source code, I found that you can pass a fully customized React component as this prop instead of just a string.

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
