### PR TITLE
docs: mention header buttons lib

### DIFF
--- a/versioned_docs/version-5.x/header-buttons.md
+++ b/versioned_docs/version-5.x/header-buttons.md
@@ -35,6 +35,8 @@ function StackScreen() {
 }
 ```
 
+When we define our button this way, the `this` variable in `options` is _not_ the `HomeScreen` instance, so you can't call `setState` or any instance methods on it. This is pretty important because it's extremely common to want the buttons in your header to interact with the screen that the header belongs to. So, we will look how to do this next.
+
 > Note that there is a community-developed solution for rendering header buttons that takes care of the correct styling - see [react-navigation-header-buttons](https://github.com/vonovak/react-navigation-header-buttons)
 
 

--- a/versioned_docs/version-5.x/header-buttons.md
+++ b/versioned_docs/version-5.x/header-buttons.md
@@ -35,7 +35,8 @@ function StackScreen() {
 }
 ```
 
-When we define our button this way, the `this` variable in `options` is _not_ the `HomeScreen` instance, so you can't call `setState` or any instance methods on it. This is pretty important because it's extremely common to want the buttons in your header to interact with the screen that the header belongs to. So, we will look how to do this next.
+> Note that there is a community-developed solution for rendering header buttons that takes care of the correct styling - see [react-navigation-header-buttons](https://github.com/vonovak/react-navigation-header-buttons)
+
 
 ## Header interaction with its screen component
 


### PR DESCRIPTION
this library was previously mentioned in there but was removed with version 5. I believe it is handy to have it mentioned in there, since I think many people will look for something like this.


shameless plug - I'm the author of the lib
