### PR TITLE
Fix hyperlinks to github react-navigation repo in version 4.x docs

### DIFF
--- a/versioned_docs/version-4.x/bottom-tab-navigator.md
+++ b/versioned_docs/version-4.x/bottom-tab-navigator.md
@@ -6,7 +6,7 @@ sidebar_label: createBottomTabNavigator
 
 A simple tab bar on the bottom of the screen that lets you switch between different routes. Routes are lazily initialized -- their screen components are not mounted until they are first focused.
 
-To use this navigator, ensure that you have [react-navigation and its dependencies installed](getting-started.md), then install [`react-navigation-tabs`](https://github.com/react-navigation/tabs).
+To use this navigator, ensure that you have [react-navigation and its dependencies installed](getting-started.md), then install [`react-navigation-tabs`](https://github.com/react-navigation/react-navigation/tree/4.x/packages/tabs).
 
 ```bash npm2yarn
 npm install react-navigation-tabs

--- a/versioned_docs/version-4.x/drawer-navigator.md
+++ b/versioned_docs/version-4.x/drawer-navigator.md
@@ -4,7 +4,7 @@ title: createDrawerNavigator
 sidebar_label: createDrawerNavigator
 ---
 
-To use this navigator, ensure that you have [react-navigation and its dependencies installed](getting-started.md), then install [`react-navigation-drawer`](https://github.com/react-navigation/drawer).
+To use this navigator, ensure that you have [react-navigation and its dependencies installed](getting-started.md), then install [`react-navigation-drawer`](https://github.com/react-navigation/react-navigation/tree/4.x/packages/drawer).
 
 ```bash npm2yarn
 npm install react-navigation-drawer

--- a/versioned_docs/version-4.x/hello-react-navigation.md
+++ b/versioned_docs/version-4.x/hello-react-navigation.md
@@ -10,7 +10,7 @@ React Navigation's stack navigator provides a way for your app to transition bet
 
 Lets start by demonstrating the most common navigator, `createStackNavigator`.
 
-Before continuing, first install [`react-navigation-stack`](https://github.com/react-navigation/stack):
+Before continuing, first install [`react-navigation-stack`](https://github.com/react-navigation/react-navigation/tree/4.x/packages/stack):
 
 ```bash npm2yarn
 npm install react-navigation-stack @react-native-community/masked-view react-native-safe-area-context

--- a/versioned_docs/version-4.x/material-bottom-tab-navigator.md
+++ b/versioned_docs/version-4.x/material-bottom-tab-navigator.md
@@ -8,7 +8,7 @@ A material-design themed tab bar on the bottom of the screen that lets you switc
 
 <img src="/assets/navigators/bottom-navigation.gif" style={{ width: '420px', maxWidth: '100%' }} />
 
-To use this navigator, ensure that you have [react-navigation and its dependencies installed](getting-started.md), then install [`react-navigation-material-bottom-tabs`](https://github.com/react-navigation/material-bottom-tabs) and [react-native-paper](https://github.com/callstack/react-native-paper).
+To use this navigator, ensure that you have [react-navigation and its dependencies installed](getting-started.md), then install [`react-navigation-material-bottom-tabs`](https://github.com/react-navigation/react-navigation/tree/4.x/packages/material-bottom-tabs) and [react-native-paper](https://github.com/callstack/react-native-paper).
 
 ```bash npm2yarn
 npm install react-navigation-material-bottom-tabs react-native-paper

--- a/versioned_docs/version-4.x/material-top-tab-navigator.md
+++ b/versioned_docs/version-4.x/material-top-tab-navigator.md
@@ -6,7 +6,7 @@ sidebar_label: createMaterialTopTabNavigator
 
 A material-design themed tab bar on the top of the screen that lets you switch between different routes by tapping the route or swiping horizontally. Transitions are animated by default. Screen components for each route are mounted immediately.
 
-To use this navigator, ensure that you have [react-navigation and its dependencies installed](getting-started.md), then install [`react-navigation-tabs`](https://github.com/react-navigation/tabs).
+To use this navigator, ensure that you have [react-navigation and its dependencies installed](getting-started.md), then install [`react-navigation-tabs`](https://github.com/react-navigation/react-navigation/tree/4.x/packages/tabs).
 
 ```bash npm2yarn
 npm install react-navigation-tabs

--- a/versioned_docs/version-4.x/navigation-views.md
+++ b/versioned_docs/version-4.x/navigation-views.md
@@ -10,9 +10,9 @@ Navigation views are controlled React components that can present the current na
 
 ## Built in Views
 
-- [StackView](https://github.com/react-navigation/stack/blob/1.0/src/views/StackView/StackView.tsx) - Present a stack that looks suitable on any platform
-    + [StackViewCard](https://github.com/react-navigation/stack/blob/1.0/src/views/StackView/StackViewCard.tsx) - Present one card from the card stack, with gestures
-    + [Header](https://github.com/react-navigation/stack/blob/1.0/src/views/Header/Header.tsx) - The header view for the card stack
-- [SwitchView](https://github.com/react-navigation/core/blob/ad6e5cecccb8bce081f773fdff7af000e0450746/src/views/SwitchView/SwitchView.js) - A navigator that only ever show one screen at a time, useful for authentication flows.
-- [Tabs](https://github.com/react-navigation/tabs) - A configurable tab switcher / pager
-- [Drawer](https://github.com/react-navigation/drawer) - A view with a drawer that slides from the left
+- [StackView](https://github.com/react-navigation/react-navigation/blob/4.x/packages/stack/src/views/StackView.tsx) - Present a stack that looks suitable on any platform
+  - [StackViewCard](https://github.com/react-navigation/stack/blob/1.0/src/views/StackView/StackViewCard.tsx) - Present one card from the card stack, with gestures
+  - [Header](https://github.com/react-navigation/stack/blob/1.0/src/views/Header/Header.tsx) - The header view for the card stack
+- [SwitchView](https://github.com/react-navigation/react-navigation/blob/4.x/packages/core/src/views/SwitchView/SwitchView.js) - A navigator that only ever show one screen at a time, useful for authentication flows.
+- [Tabs](https://github.com/react-navigation/react-navigation/tree/4.x/packages/tabs) - A configurable tab switcher / pager
+- [Drawer](https://github.com/react-navigation/react-navigation/tree/4.x/packages/drawer) - A view with a drawer that slides from the left

--- a/versioned_docs/version-4.x/routers.md
+++ b/versioned_docs/version-4.x/routers.md
@@ -10,8 +10,8 @@ Routers define a component's navigation state, and they allow the developer to d
 
 `react-navigation` ships with a few standard routers:
 
-- [StackRouter](https://github.com/react-navigation/core/blob/master/src/routers/StackRouter.js)
-- [TabRouter](https://github.com/react-navigation/core/blob/master/src/routers/TabRouter.js)
+- [StackRouter](https://github.com/react-navigation/react-navigation/blob/4.x/packages/core/src/routers/StackRouter.js)
+- [TabRouter](https://github.com/react-navigation/react-navigation/blob/4.x/packages/core/src/routers/TabRouter.js)
 
 ## Using Routers
 

--- a/versioned_docs/version-4.x/stack-navigator.md
+++ b/versioned_docs/version-4.x/stack-navigator.md
@@ -8,7 +8,7 @@ Provides a way for your app to transition between screens where each new screen 
 
 By default the stack navigator is configured to have the familiar iOS and Android look & feel: new screens slide in from the right on iOS, fade in from the bottom on Android. On iOS the stack navigator can also be configured to a modal style where screens slide in from the bottom.
 
-To use this navigator, ensure that you have [react-navigation and its dependencies installed](getting-started.md), then install [`react-navigation-stack`](https://github.com/react-navigation/stack).
+To use this navigator, ensure that you have [react-navigation and its dependencies installed](getting-started.md), then install [`react-navigation-stack`](https://github.com/react-navigation/react-navigation/tree/4.x/packages/stack).
 
 ```bash npm2yarn
 npm install react-navigation-stack @react-native-community/masked-view
@@ -204,7 +204,7 @@ Function which returns a React Element to display on the right side of the heade
 
 #### `headerLeft`
 
-Function which returns a React Element to display on the left side of the header. When a function is used, it receives a number of arguments when rendered (`onPress`, `label`, `labelStyle` and more - check [types.tsx](https://github.com/react-navigation/stack/blob/master/src/types.tsx) for the complete list).
+Function which returns a React Element to display on the left side of the header. When a function is used, it receives a number of arguments when rendered (`onPress`, `label`, `labelStyle` and more - check [types.tsx](https://github.com/react-navigation/react-navigation/blob/4.x/packages/stack/src/types.tsx) for the complete list).
 
 #### `headerStyle`
 


### PR DESCRIPTION
The hyperlinks were pointing to the archived `react-navigation` repo so updated them to active repo and that particular branch file. 
