### PR TITLE
docs: fix link in More Resources page

### DIFF
--- a/versioned_docs/version-3.x/more-resources.md
+++ b/versioned_docs/version-3.x/more-resources.md
@@ -6,7 +6,7 @@ sidebar_label: More Resources
 
 # Talks
 
-- [Mobile App Development with React Native at Harvard Extension School](https://cs50.github.io/mobile/lectures): Lecture 6 covers React Navigation, includes exercises, slides, and video.
+- [Mobile App Development with React Native at Harvard Extension School](https://cs50.harvard.edu/mobile/2018/): Lecture 6 covers React Navigation, includes exercises, slides, and video.
 
 - [Mobile Navigation at React Alicante](https://www.youtube.com/watch?v=GBhdooVxX6Q): An overview and comparison of the approaches taken by react-native-navigation and react-navigation.
 

--- a/versioned_docs/version-4.x/more-resources.md
+++ b/versioned_docs/version-4.x/more-resources.md
@@ -6,7 +6,7 @@ sidebar_label: More Resources
 
 # Talks
 
-- [Mobile App Development with React Native at Harvard Extension School](https://cs50.github.io/mobile/lectures): Lecture 6 covers React Navigation, includes exercises, slides, and video.
+- [Mobile App Development with React Native at Harvard Extension School](https://cs50.harvard.edu/mobile/2018/): Lecture 6 covers React Navigation, includes exercises, slides, and video.
 
 - [Mobile Navigation at React Alicante](https://www.youtube.com/watch?v=GBhdooVxX6Q): An overview and comparison of the approaches taken by react-native-navigation and react-navigation.
 

--- a/versioned_docs/version-5.x/more-resources.md
+++ b/versioned_docs/version-5.x/more-resources.md
@@ -6,7 +6,7 @@ sidebar_label: More Resources
 
 # Talks
 
-- [Mobile App Development with React Native at Harvard Extension School](https://cs50.github.io/mobile/lectures): Lecture 6 covers React Navigation, includes exercises, slides, and video.
+- [Mobile App Development with React Native at Harvard Extension School](https://cs50.harvard.edu/mobile/2018/): Lecture 6 covers React Navigation, includes exercises, slides, and video.
 
 - [Mobile Navigation at React Alicante](https://www.youtube.com/watch?v=GBhdooVxX6Q): An overview and comparison of the approaches taken by react-native-navigation and react-navigation.
 


### PR DESCRIPTION
Fix link to Harvard Extension School page

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
