### PR TITLE
Link directly to #react-navigation on Reactiflux

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -84,7 +84,7 @@ module.exports = {
           items: [
             {
               label: 'Chat in our Discord channel',
-              href: 'https://discord.gg/reactiflux',
+              href: 'https://discord.gg/4xEK3nD',
             },
             {
               label: 'Get help on Stack Overflow',

--- a/src/pages/help.js
+++ b/src/pages/help.js
@@ -4,30 +4,58 @@ import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-export default function Help () {
+export default function Help() {
   const context = useDocusaurusContext();
   const { siteConfig = {} } = context;
 
   const supportLinks = [
     {
-      content: <p>Learn more using the <Link to={useBaseUrl('/docs/getting-started')}> documentation on this site</Link>.</p>,
+      content: (
+        <p>
+          Learn more using the{' '}
+          <Link to={useBaseUrl('/docs/getting-started')}>
+            {' '}
+            documentation on this site
+          </Link>
+          .
+        </p>
+      ),
       title: <p>Browse Docs and API</p>,
     },
     {
-      content: <p>Ask questions about the documentation and project in the `#react-navigation` channel on the <Link to={useBaseUrl('https://discord.gg/reactiflux')}> Reactiflux Discord</Link>.</p>,
+      content: (
+        <p>
+          Ask questions about the documentation and project in the
+          `#react-navigation` channel on the{' '}
+          <Link to={useBaseUrl('https://discord.gg/4xEK3nD')}>
+            {' '}
+            Reactiflux Discord
+          </Link>
+          .
+        </p>
+      ),
       title: <p>Join the community</p>,
     },
     {
-      content:
-        <p>Read the release notes for new versions of React Navigation in the <Link to={useBaseUrl('https://github.com/react-navigation/react-navigation/releases')}>releases tab on the Github repository</Link>.</p>,
+      content: (
+        <p>
+          Read the release notes for new versions of React Navigation in the{' '}
+          <Link
+            to={useBaseUrl(
+              'https://github.com/react-navigation/react-navigation/releases'
+            )}
+          >
+            releases tab on the Github repository
+          </Link>
+          .
+        </p>
+      ),
       title: <p>Stay up to date</p>,
     },
   ];
 
   return (
-    <Layout
-      title={`${siteConfig.title}`}
-    >
+    <Layout title={`${siteConfig.title}`}>
       <div className="docMainWrapper wrapper">
         <div className="container margin-vert--xl">
           <header className="postHeader">
@@ -38,24 +66,23 @@ export default function Help () {
             <a href="https://github.com/react-navigation/react-navigation/issues">
               post an issue
             </a>{' '}
-            and be sure to fill out the issue template. If you believe there is a feature missing, please{' '}
+            and be sure to fill out the issue template. If you believe there is
+            a feature missing, please{' '}
             <a href="https://react-navigation.canny.io/feature-requests">
-               create a feature request on Canny
+              create a feature request on Canny
             </a>
-            , {`or if you're feeling up for the task of proposing an API for the feature, `}
-            <a href="https://github.com/react-navigation/rfcs">
-              submit a RFC!
-            </a>{' '}
-             If you just need some help, try joining us in the
-            {' '}<code>react-navigation</code>{' '}
-            channel on
+            ,{' '}
+            {`or if you're feeling up for the task of proposing an API for the feature, `}
+            <a href="https://github.com/react-navigation/rfcs">submit a RFC!</a>{' '}
+            If you just need some help, try joining us in the{' '}
+            <code>react-navigation</code> channel on
             <a href="https://discord.gg/4xEK3nD"> Discord </a>
             or{' '}
             <a href="https://stackoverflow.com/questions/tagged/react-navigation">
-               post a question to StackOverflow
-            </a>.
+              post a question to StackOverflow
+            </a>
+            .
           </p>
-          
         </div>
         {supportLinks && supportLinks.length && (
           <section className="margin-vert--xl">


### PR DESCRIPTION
Reverts #881 because we fixed the issues with directly linking to channels