### PR TITLE
docs: add react-native-collapsible-tab-view link

### DIFF
--- a/versioned_docs/version-5.x/community-libraries-and-navigators.md
+++ b/versioned_docs/version-5.x/community-libraries-and-navigators.md
@@ -68,3 +68,11 @@ Easily handle Android back button behavior with React-Navigation with a componen
 
 [github.com/vonovak/react-navigation-backhandler](https://github.com/vonovak/react-navigation-backhandler)
 
+## react-native-collapsible-tab-view
+
+A simple wrapper for react-native-tab-view that exports a navigator with collapsible header above the tab view.
+
+#### Links
+
+[github.com/pedrobern/react-native-collapsible-tab-view](https://github.com/react-native-collapsible-tab-view)
+


### PR DESCRIPTION
<!---
# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
--->

Add [react-native-collapsible-tab-view](https://github.com/PedroBern/react-native-collapsible-tab-view) to the Community-developed Navigators and Libraries.

This PR affects only the `version-5.x` of the docs.

It's a wrapper for the [react-native-tab-view](https://github.com/satya164/react-native-tab-view), exporting a navigator to integrate with react-navigation and render a collapsible header above the tab-view.

Below is the expo preview of the example app:

- [View it with Expo](https://expo.io/@pedrobern/react-native-collapsible-tab-view-demos).

<a href="https://expo.io/@pedrobern/react-native-collapsible-tab-view-demos"><img src="https://api.qrserver.com/v1/create-qr-code/?size=400x400&data=exp://exp.host/@pedrobern/react-native-collapsible-tab-view-demos" height="200px" width="200px"></a>
