### PR TITLE
Fix typo in params section

### DIFF
--- a/versioned_docs/version-5.x/params.md
+++ b/versioned_docs/version-5.x/params.md
@@ -163,7 +163,7 @@ navigation.navigate('Profile', {
 });
 ```
 
-This looks convenient, and let's you access the user objects with `route.params.user` without any extra work.
+This looks convenient, and lets you access the user objects with `route.params.user` without any extra work.
 
 However, this is an anti-pattern. Data such as user objects should be in your global store instead of the navigation state. Otherwise you have the same data duplicated in multiple places. This can leads to bugs such as the profile screen showing outdated data even if the user object has changed after navigation.
 


### PR DESCRIPTION
Let's = let us, while here it should be "lets" as in "allows"

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
