### PR TITLE
feat: Hide Snack query params on URL bar

### DIFF
--- a/src/SnackHelpers.js
+++ b/src/SnackHelpers.js
@@ -49,7 +49,8 @@ function getSnackUrl(options) {
     `https://snack.expo.io?platform=${DEFAULT_PLATFORM}&name=` +
     encodeURIComponent(label) +
     '&dependencies=' +
-    encodeURIComponent(DEPS_VERSIONS[currentMajorVersion].join(','));
+    encodeURIComponent(DEPS_VERSIONS[currentMajorVersion].join(',')) +
+    '&hideQueryParams=true';
 
   // todo: this is ridiculous but there's no other way i can see to get the
   // current version from the html or the url, given that the root url is


### PR DESCRIPTION
# Why

Hides the query parameters from the URL bar when opening a Snack example. This is made possible by the new `hideQueryParams=true` option https://github.com/expo/snack/blob/main/docs/url-query-parameters.md

**before**

![image](https://user-images.githubusercontent.com/6184593/103918884-ab959b80-510f-11eb-93c3-fea3c69d7dcf.png)

**after**

![image](https://user-images.githubusercontent.com/6184593/103918939-be0fd500-510f-11eb-8fd1-a848be171918.png)

 # How

- Add `'&hideQueryParams=true` to url