### PR TITLE
Fix a typo

### DIFF
--- a/versioned_docs/version-5.x/screen-tracking.md
+++ b/versioned_docs/version-5.x/screen-tracking.md
@@ -41,7 +41,7 @@ export default function App() {
           Analytics.setCurrentScreen(currentRouteName);
         }
 
-        // Save the current route name for later comparision
+        // Save the current route name for later comparison
         routeNameRef.current = currentRouteName;
       }}
     >


### PR DESCRIPTION
Thank you all contributors!

I have found a minor typo issue in example code.
wrong: comparision ( including `i` after `s` )
correct: comparison
