### PR TITLE
fix: Update getting-started.md for drawer swipe gesture to work on Android

### DIFF
--- a/versioned_docs/version-5.x/getting-started.md
+++ b/versioned_docs/version-5.x/getting-started.md
@@ -57,7 +57,8 @@ From React Native 0.60 and higher, [linking is automatic](https://github.com/rea
 
 ### Updating MainActivity.java
 
-Location:
+Files location:
+
 > ..\MyApp\android\app\src\main\java\com\MyApp\MainActivity.java
 
 React Native 0.60 migrated from Support Library to AndroidX. React Native Gesture Handler is not yet compatible with AndroidX.

--- a/versioned_docs/version-5.x/getting-started.md
+++ b/versioned_docs/version-5.x/getting-started.md
@@ -57,7 +57,7 @@ From React Native 0.60 and higher, [linking is automatic](https://github.com/rea
 
 ### Updating MainActivity.java
 
-Files location:
+Location:
 
 > ..\MyApp\android\app\src\main\java\com\MyApp\MainActivity.java
 

--- a/versioned_docs/version-5.x/getting-started.md
+++ b/versioned_docs/version-5.x/getting-started.md
@@ -55,6 +55,46 @@ npm install react-native-reanimated react-native-gesture-handler react-native-sc
 
 From React Native 0.60 and higher, [linking is automatic](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md). So you **don't need to run** `react-native link`.
 
+### Updating MainActivity.java
+
+Location:
+> ..\MyApp\android\app\src\main\java\com\MyApp\MainActivity.java
+
+React Native 0.60 migrated from Support Library to AndroidX. React Native Gesture Handler is not yet compatible with AndroidX.
+Make sure to update the React Native CLI to the latest version which runs jetifier – the AndroidX migration tool – during the run-android command.
+
+```
+package com.swmansion.gesturehandler.react.example;
+
+import com.facebook.react.ReactActivity;
+//Copy from this
+ import com.facebook.react.ReactActivityDelegate;
+ import com.facebook.react.ReactRootView;
+ import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
+//To this
+public class MainActivity extends ReactActivity {
+
+  @Override
+  protected String getMainComponentName() {
+    return "Example";
+  }
+
+//Copy from this
+  @Override
+  protected ReactActivityDelegate createReactActivityDelegate() {
+    return new ReactActivityDelegate(this, getMainComponentName()) {
+      @Override
+      protected ReactRootView createRootView() {
+       return new RNGestureHandlerEnabledRootView(MainActivity.this);
+      }
+    };
+  }
+//To this
+}
+```
+
+## For IOS
+
 If you're on a Mac and developing for iOS, you need to install the pods (via [Cocoapods](https://cocoapods.org/)) to complete the linking.
 
 ```sh


### PR DESCRIPTION
# Read Me Please

To fix drawer navigation not responding to the swipe on android, MainActivity.java need to be updated to make the gesture handlers work properly. Thus, I recommended putting the instructions in the docs for easier initial setup and saving much more time.