### PR TITLE
Fix typo in LogBox.ignoreLogs for passing non-serializable values

### DIFF
--- a/versioned_docs/version-5.x/troubleshooting.md
+++ b/versioned_docs/version-5.x/troubleshooting.md
@@ -266,7 +266,7 @@ code would be written as follows:
 >import { LogBox } from 'react-native';
 >
 >LogBox.ignoreLogs([
->  'Non-serializable values were found in the navigation >state',
+>  'Non-serializable values were found in the navigation state',
 >]);
 >```
 


### PR DESCRIPTION
Removed an unnecessary `>` in `Non-serializable values were found in the navigation >state` 👍 

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
