### PR TITLE
fix: Grammar update in v5.x documentation

### DIFF
--- a/versioned_docs/version-5.x/navigation-events.md
+++ b/versioned_docs/version-5.x/navigation-events.md
@@ -10,7 +10,7 @@ Following are the built-in events available with every navigator:
 
 - `focus` - This event is emitted when the screen comes into focus
 - `blur` - This event is emitted when the screen goes out of focus
-- `beforeRemove` (version 5.7+ only) - This event is emitted when the user is a leaving the screen, there's a chance to [prevent the user from leaving](preventing-going-back.md)
+- `beforeRemove` (version 5.7+ only) - This event is emitted when the user is leaving a screen, there's a chance to [prevent the user from leaving](preventing-going-back.md)
 - `state` (advanced) - This event is emitted when the navigator's state changes
 
 Apart from these, each navigator can emit their own custom events. For example, stack navigator emits `transitionStart` and `transitionEnd` events, tab navigator emits `tabPress` event etc. You can find details about the events emitted on the individual navigator's documentation.

--- a/versioned_docs/version-5.x/navigation-events.md
+++ b/versioned_docs/version-5.x/navigation-events.md
@@ -10,7 +10,7 @@ Following are the built-in events available with every navigator:
 
 - `focus` - This event is emitted when the screen comes into focus
 - `blur` - This event is emitted when the screen goes out of focus
-- `beforeRemove` (version 5.7+ only) - This event is emitted when the user is leaving a screen, there's a chance to [prevent the user from leaving](preventing-going-back.md)
+- `beforeRemove` (version 5.7+ only) - This event is emitted when the user is leaving the screen, there's a chance to [prevent the user from leaving](preventing-going-back.md)
 - `state` (advanced) - This event is emitted when the navigator's state changes
 
 Apart from these, each navigator can emit their own custom events. For example, stack navigator emits `transitionStart` and `transitionEnd` events, tab navigator emits `tabPress` event etc. You can find details about the events emitted on the individual navigator's documentation.


### PR DESCRIPTION
Grammar updates

This is a simple grammar error spotted in v5.x ( Navigation Events ) documentaion.

 Before
 
 
![Screen Shot 2021-02-19 at 6 33 42 PM](https://user-images.githubusercontent.com/37703642/108509709-9b163a80-72e3-11eb-990d-48d6a5d012b0.png)

After


![Screen Shot 2021-02-19 at 6 53 41 PM](https://user-images.githubusercontent.com/37703642/108509854-cbf66f80-72e3-11eb-9a7e-b9a0d4035f0f.png)
