### PR TITLE
fix: Remove reference to createTabNavigator()

### DIFF
--- a/versioned_docs/version-5.x/screen-options-resolution.md
+++ b/versioned_docs/version-5.x/screen-options-resolution.md
@@ -13,7 +13,7 @@ Let's take for example a tab navigator that contains a stack in each tab. What h
 <samp id="stack-in-tab-nav-options" />
 
 ```js
-const Tab = createTabNavigator();
+const Tab = createBottomTabNavigator();
 const HomeStack = createStackNavigator();
 const SettingsStack = createStackNavigator();
 


### PR DESCRIPTION
Remove reference to createTabNavigator() - it's been removed in `react-navigation@3.x`
