### PR TITLE
Enable RSS & Atom feeds

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -162,6 +162,11 @@ module.exports = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
+        blog: {
+          feedOptions: {
+            type: 'all',
+          },
+        },
       },
     ],
   ],


### PR DESCRIPTION
It generates RSS and Atom feeds for the blog and the needed tags in `<head>`.

This has been enabled by default in recent Docusaurus versions (see https://github.com/facebook/docusaurus/pull/3842)

Fixes #965

