### PR TITLE
docs: add intent-filter for App Links

### DIFF
--- a/versioned_docs/version-5.x/deep-linking.md
+++ b/versioned_docs/version-5.x/deep-linking.md
@@ -238,6 +238,12 @@ If you want to add it manually, open up `SimpleApp/android/app/src/main/AndroidM
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />
     </intent-filter>
+    <intent-filter android:autoVerify="true">
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.DEFAULT" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" android:host="mychat.com" android:pathPrefix="/available-path-for-android" />
+    </intent-filter>
     <intent-filter>
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
### Add App Link to bare RN manual Android Setup

I just config Deep Links as doc said on our project using this doc and [Configuring Links](https://reactnavigation.org/docs/configuring-links/) doc.
Android and iOS URI Scheme was fine but App Links (https prefixes in linking config object) in android didn't worked as expected.

After some research I found [Implement deep linking in React Native apps using Universal links and URL schema](https://saadibrah.im/implement-deep-linking-in-react-native-apps-using-universal-links-and-url-schema/) and [Create Deep Links to App Content
](https://developer.android.com/training/app-links/deep-linking) and figured that App Links should be configured in `AndroidManifest.json` too! (rational actually).

So I add these changes to `AndroidManifest.json` and problem solved.

Maybe I had to create new issue first :)

Notes:
  - I don't know why such an obvious thing didn't exist in document and why other people didn't have this issue too.
  - I didn't check Universal Link on iOS and don't know if it works or not
  - I don't know why `uri-scheme` command doesn't add `intent-filter` for app links automatically. Strange!

---

Device and Project info
```
`react-native`: `0.62.2`
`react-navigation/native`: `5.6.1`
Physical Device Android version: `10`
```

