### PR TITLE
Update mock of NativeAnimatedHelper

### DIFF
--- a/versioned_docs/version-5.x/testing.md
+++ b/versioned_docs/version-5.x/testing.md
@@ -29,7 +29,7 @@ jest.mock('react-native-reanimated', () => {
 });
 
 // Silence the warning: Animated: `useNativeDriver` is not supported because the native animated module is missing
-jest.mock('react-native/Libraries/Animated/src/NativeAnimatedHelper');
+jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper');
 ```
 
 Then we need to use this setup file in our jest config. You can add it under `setupFiles` option in a `jest.config.js` file or the `jest` key in `package.json`:


### PR DESCRIPTION
Apparently there is no "src" folder inside react-native/Libraries/Animated anymore. Thus, trying to mock by using it in the path doesn't work and all JEST tests involving react-navigation break completely.