### PR TITLE
Fix invalid link in documentation for stack-navigator

### DIFF
--- a/versioned_docs/version-5.x/stack-navigator.md
+++ b/versioned_docs/version-5.x/stack-navigator.md
@@ -220,7 +220,7 @@ Function which returns a React Element to display on the right side of the heade
 
 #### `headerLeft`
 
-Function which returns a React Element to display on the left side of the header. When a function is used, it receives a number of arguments when rendered (`tintColor`, `pressColor`, `pressOpacity` and more - check [types.tsx](https://github.com/react-navigation/react-navigation/blob/main/packages/elements/src/types.tsx#L58-L62) for the complete list).
+Function which returns a React Element to display on the left side of the header. When a function is used, it receives a number of arguments when rendered (`onPress`, `label`, `labelStyle` and more - check [types.tsx](https://github.com/react-navigation/react-navigation/blob/5.x/packages/stack/src/types.tsx#L377-L445) for the complete list).
 
 By default, `HeaderBackButton` component is used. You can implement it and use it to override the back button press, for example:
 

--- a/versioned_docs/version-5.x/stack-navigator.md
+++ b/versioned_docs/version-5.x/stack-navigator.md
@@ -220,7 +220,7 @@ Function which returns a React Element to display on the right side of the heade
 
 #### `headerLeft`
 
-Function which returns a React Element to display on the left side of the header. When a function is used, it receives a number of arguments when rendered (`onPress`, `label`, `labelStyle` and more - check [types.tsx](https://github.com/react-navigation/react-navigation/blob/main/packages/stack/src/types.tsx#L373-L441) for the complete list).
+Function which returns a React Element to display on the left side of the header. When a function is used, it receives a number of arguments when rendered (`tintColor`, `pressColor`, `pressOpacity` and more - check [types.tsx](https://github.com/react-navigation/react-navigation/blob/main/packages/elements/src/types.tsx#L58-L62) for the complete list).
 
 By default, `HeaderBackButton` component is used. You can implement it and use it to override the back button press, for example:
 


### PR DESCRIPTION
The headerLeft option documentation has an invalid link and lists the wrong property names.