### PR TITLE
Update documentation to correctly use expo-firebase-analytics

### DIFF
--- a/versioned_docs/version-5.x/screen-tracking.md
+++ b/versioned_docs/version-5.x/screen-tracking.md
@@ -44,6 +44,7 @@ export default () => {
             screen_name: currentRouteName,
             screen_class: currentRouteName
           });
+          // or: await Analytics.setCurrentScreen('currentRouteName');
         }
 
         // Save the current route name for later comparison

--- a/versioned_docs/version-5.x/screen-tracking.md
+++ b/versioned_docs/version-5.x/screen-tracking.md
@@ -40,7 +40,7 @@ export default () => {
           // The line below uses the expo-firebase-analytics tracker
           // https://docs.expo.io/versions/latest/sdk/firebase-analytics/
           // Change this line to use another Mobile analytics SDK
-          await analytics().logScreenView({
+          await Analytics.logEvent('CURRENT_SCREEN', {
             screen_name: currentRouteName,
             screen_class: currentRouteName
           });


### PR DESCRIPTION
Updated documentation for the sample screen tracking code. The current example wouldn't have worked. The import was incorrect and the `logScreenView` function does not exist in `expo-firebase-analytics` package from what I can tell: https://docs.expo.io/versions/latest/sdk/firebase-analytics/#methods