### PR TITLE
fix: Changed @react-native-community/masked-view to @react-native-masked-view/masked-view in version 5 docs

### DIFF
--- a/src/SnackHelpers.js
+++ b/src/SnackHelpers.js
@@ -14,7 +14,7 @@ const DEPS_VERSIONS = {
   ],
   '5': [
     '@expo/vector-icons@*',
-    '@react-native-community/masked-view@*',
+    '@react-native-masked-view/masked-view@*',
     "@react-navigation/bottom-tabs@^5.8.0",
     "@react-navigation/drawer@^5.9.0",
     "@react-navigation/material-bottom-tabs@^5.2.16",
@@ -30,7 +30,7 @@ const DEPS_VERSIONS = {
   ],
   '6': [
     '@expo/vector-icons@*',
-    '@react-native-community/masked-view@*',
+    '@react-native-masked-view/masked-view@*',
     'react-native-gesture-handler@*',
     'react-native-pager-view@*',
     'react-native-paper@^4.7.2',

--- a/versioned_docs/version-5.x/getting-started.md
+++ b/versioned_docs/version-5.x/getting-started.md
@@ -27,14 +27,14 @@ npm install @react-navigation/native
 
 React Navigation is made up of some core utilities and those are then used by navigators to create the navigation structure in your app. Don't worry too much about this for now, it'll become clear soon enough! To frontload the installation work, let's also install and configure dependencies used by most navigators, then we can move forward with starting to write some code.
 
-The libraries we will install now are [`react-native-gesture-handler`](https://github.com/software-mansion/react-native-gesture-handler), [`react-native-reanimated`](https://github.com/software-mansion/react-native-reanimated), [`react-native-screens`](https://github.com/software-mansion/react-native-screens) and [`react-native-safe-area-context`](https://github.com/th3rdwave/react-native-safe-area-context) and [`@react-native-community/masked-view`](https://github.com/react-native-community/react-native-masked-view). If you already have these libraries installed and at the latest version, you are done here! Otherwise, read on.
+The libraries we will install now are [`react-native-gesture-handler`](https://github.com/software-mansion/react-native-gesture-handler), [`react-native-reanimated`](https://github.com/software-mansion/react-native-reanimated), [`react-native-screens`](https://github.com/software-mansion/react-native-screens) and [`react-native-safe-area-context`](https://github.com/th3rdwave/react-native-safe-area-context) and [`@react-native-masked-view/masked-view`](https://github.com/react-native-masked-view/masked-view). If you already have these libraries installed and at the latest version, you are done here! Otherwise, read on.
 
 ### Installing dependencies into an Expo managed project
 
 In your project directory, run:
 
 ```sh
-expo install react-native-gesture-handler react-native-reanimated react-native-screens react-native-safe-area-context @react-native-community/masked-view
+expo install react-native-gesture-handler react-native-reanimated react-native-screens react-native-safe-area-context @react-native-masked-view/masked-view
 ```
 
 This will install versions of these libraries that are compatible.
@@ -46,7 +46,7 @@ You can now continue to ["Hello React Navigation"](hello-react-navigation.md) to
 In your project directory, run:
 
 ```bash npm2yarn
-npm install react-native-reanimated react-native-gesture-handler react-native-screens react-native-safe-area-context @react-native-community/masked-view
+npm install react-native-reanimated react-native-gesture-handler react-native-screens react-native-safe-area-context @react-native-masked-view/masked-view
 ```
 
 > Note: You might get warnings related to peer dependencies after installation. They are usually caused by incorrect version ranges specified in some packages. You can safely ignore most warnings as long as your app builds.

--- a/versioned_docs/version-5.x/hello-react-navigation.md
+++ b/versioned_docs/version-5.x/hello-react-navigation.md
@@ -18,7 +18,7 @@ The libraries we've installed so far are the building blocks and shared foundati
 npm install @react-navigation/stack
 ```
 
-> 💡 `@react-navigation/stack` depends on `@react-native-community/masked-view` and the other libraries that we installed in [Getting started](getting-started.md). If you haven't installed those yet, head over to that page and follow the installation instructions.
+> 💡 `@react-navigation/stack` depends on `@react-native-masked-view/masked-view` and the other libraries that we installed in [Getting started](getting-started.md). If you haven't installed those yet, head over to that page and follow the installation instructions.
 
 ### Creating a stack navigator
 


### PR DESCRIPTION
Changed @react-native-community/masked-view to @react-native-masked-view/masked-view in version 5 docs

The changes were made in versioned_docs/version-5.x

Changes were also made in src/SnackHelpers.js