### PR TITLE
Changing the masked-view npm path

### DIFF
--- a/versioned_docs/version-5.x/getting-started.md
+++ b/versioned_docs/version-5.x/getting-started.md
@@ -46,7 +46,7 @@ You can now continue to ["Hello React Navigation"](hello-react-navigation.md) to
 In your project directory, run:
 
 ```bash npm2yarn
-npm install react-native-reanimated react-native-gesture-handler react-native-screens react-native-safe-area-context @react-native-community/masked-view
+npm install react-native-reanimated react-native-gesture-handler react-native-screens react-native-safe-area-context @react-native-masked-view/masked-view
 ```
 
 > Note: You might get warnings related to peer dependencies after installation. They are usually caused by incorrect version ranges specified in some packages. You can safely ignore most warnings as long as your app builds.


### PR DESCRIPTION
I change the masked-view path to @react-native-masked-view/masked-view.

The old one is getting some issues making impossible the intalation of navegation stack pack

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
