### PR TITLE
fix: fixes screen-tracking#v5 example

### DIFF
--- a/versioned_docs/version-5.x/screen-tracking.md
+++ b/versioned_docs/version-5.x/screen-tracking.md
@@ -40,10 +40,7 @@ export default () => {
           // The line below uses the expo-firebase-analytics tracker
           // https://docs.expo.io/versions/latest/sdk/firebase-analytics/
           // Change this line to use another Mobile analytics SDK
-          await analytics().logScreenView({
-            screen_name: currentRouteName,
-            screen_class: currentRouteName
-          });
+          Analytics.setCurrentScreen(currentRouteName);
         }
 
         // Save the current route name for later comparison


### PR DESCRIPTION
Fix screen-tracking code sample by using Analytics.setCurrentScreen from expo-firebase-analytics. Regression from this PR: https://github.com/react-navigation/react-navigation.github.io/pull/900
