### PR TITLE
docs: update custom android back handling code to match RN docs

### DIFF
--- a/versioned_docs/version-6.x/custom-android-back-button-handling.md
+++ b/versioned_docs/version-6.x/custom-android-back-button-handling.md
@@ -25,10 +25,9 @@ function ScreenWithCustomBackBehavior() {
         }
       };
 
-      BackHandler.addEventListener('hardwareBackPress', onBackPress);
+      const backHandler = BackHandler.addEventListener('hardwareBackPress', onBackPress);
 
-      return () =>
-        BackHandler.removeEventListener('hardwareBackPress', onBackPress);
+      return () => backHandler.remove();
     }, [isSelectionModeEnabled, disableSelectionMode])
   );
 


### PR DESCRIPTION
Updated the code snippet for custom android back handling to match the [functional component example for BackHandling](https://reactnative.dev/docs/backhandler) in the React Native documentation. It's a simple change but could mitigate potential mistakes with string typos.