### PR TITLE
docs: Incorrect import in handling-iphonex.md

### DIFF
--- a/versioned_docs/version-4.x/handling-iphonex.md
+++ b/versioned_docs/version-4.x/handling-iphonex.md
@@ -38,7 +38,7 @@ export default createStackNavigator({
 
 ![Text hidden by iPhoneX UI elements](/assets/iphoneX/02-iphonex-content-hidden.png)
 
-To fix this issue you can wrap your content in a `SafeAreaView`, which can be imported from `react-navigation`. Recall that `SafeAreaView` should not wrap entire navigators, just the screen components or any content in them.
+To fix this issue you can wrap your content in a `SafeAreaView`, which can be imported from `react-native-safe-area-view`. Recall that `SafeAreaView` should not wrap entire navigators, just the screen components or any content in them.
 
 ```jsx
 import SafeAreaView from 'react-native-safe-area-view';


### PR DESCRIPTION
In the example the SafeAreaView is imported from `react-native-safe-area-view`, but in the description it is imported from `react-navigation`, which may cause confusion.

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
