### PR TITLE
docs: Missing backtick on `headerMode` is moved to options

### DIFF
--- a/versioned_docs/version-6.x/upgrading-from-5.x.md
+++ b/versioned_docs/version-6.x/upgrading-from-5.x.md
@@ -162,7 +162,7 @@ So instead of having 2 ways to do very similar things, we have removed `headerMo
 </Stack.Navigator>
 ```
 
-### `headerMode is moved to options
+### `headerMode` is moved to options
 
 Previously, `headerMode` was a prop on the navigator, but now it needs to be specified in screen's `options` instead. To keep previous behavior, you can specify it in `screenOptions`:
 


### PR DESCRIPTION
In the Markdown file for the document, there is a missing backtick on a section heading.

Previously:

```
`headerMode is moved to options.
```

This PR resolves:

```
`headerMode` is moved to options.
```
---

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
