### PR TITLE
Correct screen tracking call to expo-firebase-analytics API.

### DIFF
--- a/versioned_docs/version-5.x/screen-tracking.md
+++ b/versioned_docs/version-5.x/screen-tracking.md
@@ -40,10 +40,7 @@ export default () => {
           // The line below uses the expo-firebase-analytics tracker
           // https://docs.expo.io/versions/latest/sdk/firebase-analytics/
           // Change this line to use another Mobile analytics SDK
-          await analytics().logScreenView({
-            screen_name: currentRouteName,
-            screen_class: currentRouteName
-          });
+          await Analytics.setCurrentScreen(currentRouteName);
         }
 
         // Save the current route name for later comparison

--- a/versioned_docs/version-6.x/screen-tracking.md
+++ b/versioned_docs/version-6.x/screen-tracking.md
@@ -42,10 +42,7 @@ export default () => {
           // The line below uses the expo-firebase-analytics tracker
           // https://docs.expo.io/versions/latest/sdk/firebase-analytics/
           // Change this line to use another Mobile analytics SDK
-          await analytics().logScreenView({
-            screen_name: currentRouteName,
-            screen_class: currentRouteName,
-          });
+          await Analytics.setCurrentScreen(currentRouteName);
         }
 
         // Save the current route name for later comparison


### PR DESCRIPTION
Fixes #1012 (which appears to apply for the v5 and v6 docs).