### PR TITLE
docs: Rename gesturesEnabled property

### DIFF
--- a/versioned_docs/version-4.x/stack-navigator.md
+++ b/versioned_docs/version-4.x/stack-navigator.md
@@ -324,7 +324,7 @@ Defaults to `push`.
 
 When `pop` is used, the `pop` animation is applied to the screen being replaced.
 
-#### `gestureEnabled`
+#### `gesturesEnabled`
 
 Whether you can use gestures to dismiss this screen. Defaults to `true` on iOS, `false` on Android.
 
@@ -631,7 +631,7 @@ const Stack = createStackNavigator(
     mode: 'modal',
     headerMode: 'none',
     defaultNavigationOptions: {
-      gestureEnabled: true,
+      gesturesEnabled: true,
       cardOverlayEnabled: true,
       ...TransitionPresets.ModalPresentationIOS,
     },


### PR DESCRIPTION
This PR is intended to rename `gestureEnabled` to `gesturesEnabled` for react-navigation 4 docs.

`gestureEnabled` works only in react-navigation 5 and 6
https://github.com/react-navigation/react-navigation/commit/167056ba91c828798d0d21c1fcad84cc2cb954e3

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
