### PR TITLE
docs: Adding troubleshooting info

### DIFF
--- a/versioned_docs/version-6.x/troubleshooting.md
+++ b/versioned_docs/version-6.x/troubleshooting.md
@@ -194,6 +194,16 @@ cd ..
 
 Now rebuild the app and test on your device or simulator.
 
+## I am getting an error "TypeError: Cannot read property 'SafeAreaProviderCompat' of undefined"
+
+The error in the stack trace that is cusing this is:
+```
+Error: Requiring module "node_modules/@react-navigation/elements/src/index.tsx", 
+which threw an exception: Error: Requiring unknown module "undefined"
+```
+
+You need to install `@react-native-masked-view/masked-view` as a dependancy until a newer version of `react-native` comes with a version of metro that will be able to handle `try..catch` around `require` statements.
+
 ## Nothing is visible on the screen after adding a `View`
 
 If you wrap the container in a `View`, make sure the `View` stretches to fill the container using `flex: 1`:


### PR DESCRIPTION
### Motivation
When trying out the `next` version of `@react-navigation/stack` the `NavigationContainer` fails to mount with an error `"TypeError: Cannot read property 'SafeAreaProviderCompat' of undefined"`

There is a comment here: https://github.com/react-navigation/react-navigation/blob/main/packages/elements/src/MaskedViewNative.tsx#L17, but it can take some time to find the cause of the error.

Instead it is better to mention the error in the troubleshooting guide for the people who want to try out the new version on their existing projects.

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
