### PR TITLE
Argument to `createURL` is now a blank string

### DIFF
--- a/versioned_docs/version-5.x/deep-linking.md
+++ b/versioned_docs/version-5.x/deep-linking.md
@@ -37,7 +37,7 @@ import * as Linking from 'expo-linking';
 // you are using older versions, you can upgrade or use Linking.makeUrl instead,
 // but note that your deep links in standalone apps will be in the format
 // scheme:/// rather than scheme:// if you use makeUrl.
-const prefix = Linking.createURL('');
+const prefix = Linking.createURL();
 
 function App() {
   const linking = {

--- a/versioned_docs/version-5.x/deep-linking.md
+++ b/versioned_docs/version-5.x/deep-linking.md
@@ -37,7 +37,7 @@ import * as Linking from 'expo-linking';
 // you are using older versions, you can upgrade or use Linking.makeUrl instead,
 // but note that your deep links in standalone apps will be in the format
 // scheme:/// rather than scheme:// if you use makeUrl.
-const prefix = Linking.createURL('/');
+const prefix = Linking.createURL('');
 
 function App() {
   const linking = {


### PR DESCRIPTION
If you use use `createURL('/')`. you will get a triple-slashed prefix in a standalone app; e.g. "myapp:///". You have to use `createURL('')`, which gives a double-slashed prefix in a standalone app; e.g. "myapp://". A blank string also produces a correct prefix in an Expo-hosted app.

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
