### PR TITLE
Add missing animation values to native-stack docs

### DIFF
--- a/versioned_docs/version-6.x/native-stack-navigator.md
+++ b/versioned_docs/version-6.x/native-stack-navigator.md
@@ -335,7 +335,10 @@ Supported values:
 
 - `default`: use the platform default animation
 - `fade`: fade screen in or out
+- `fade_from_bottom`: fade the new screen from bottom
 - `flip`: flip the screen, requires stackPresentation: "modal" (iOS only)
+- `simple_push`: default animation, but without shadow and native header transition (iOS only, uses default animation on Android)
+- `slide_from_bottom`: slide in the new screen from bottom
 - `slide_from_right`: slide in the new screen from right (Android only, uses default animation on iOS)
 - `slide_from_left`: slide in the new screen from left (Android only, uses default animation on iOS)
 - `none`: don't animate the screen


### PR DESCRIPTION
This PR adds 3 missing animation types to native-stack documentation - `fade_from_bottom `, `simple_push`, `slide_from_bottom `.

PR connected to https://github.com/react-navigation/react-navigation/pull/9788
