### PR TITLE
Fixing yarn autoconverter for broken `--save-dev` flag

### DIFF
--- a/src/plugins/remark-npm2yarn/index.js
+++ b/src/plugins/remark-npm2yarn/index.js
@@ -17,6 +17,8 @@ const convertNpmToYarn = npmCode => {
       .replace(/npm install/gm, 'yarn add')
       // run command: 'npm run start' -> 'yarn run start'
       .replace(/npm run/gm, 'yarn run')
+      // when installing, yarn uses `--dev` instead of `--save-dev`
+      .replace(/--save-dev/gm, '--dev')
   );
 };
 

--- a/src/plugins/remark-npm2yarn/index.js
+++ b/src/plugins/remark-npm2yarn/index.js
@@ -19,7 +19,6 @@ const convertNpmToYarn = npmCode => {
       .replace(/npm install/gm, 'yarn add')
       // run command: 'npm run start' -> 'yarn run start'
       .replace(/npm run/gm, 'yarn run')
-
   );
 };
 

--- a/src/plugins/remark-npm2yarn/index.js
+++ b/src/plugins/remark-npm2yarn/index.js
@@ -18,7 +18,7 @@ const convertNpmToYarn = npmCode => {
       // run command: 'npm run start' -> 'yarn run start'
       .replace(/npm run/gm, 'yarn run')
       // when installing, yarn uses `--dev` instead of `--save-dev`
-      .replace(/--save-dev/gm, '--dev')
+      .replace(/npm install --save-dev/gm, 'yarn add --dev')
   );
 };
 

--- a/src/plugins/remark-npm2yarn/index.js
+++ b/src/plugins/remark-npm2yarn/index.js
@@ -13,12 +13,13 @@ const convertNpmToYarn = npmCode => {
   return (
     npmCode
       .replace(/^npm i$/gm, 'yarn')
+      // when installing, yarn uses `--dev` instead of `--save-dev`
+      .replace(/npm install --save-dev/gm, 'yarn add --dev')
       // install: 'npm install foo' -> 'yarn add foo'
       .replace(/npm install/gm, 'yarn add')
       // run command: 'npm run start' -> 'yarn run start'
       .replace(/npm run/gm, 'yarn run')
-      // when installing, yarn uses `--dev` instead of `--save-dev`
-      .replace(/npm install --save-dev/gm, 'yarn add --dev')
+
   );
 };
 


### PR DESCRIPTION
`yarn add --save-dev X` is wrong, `yarn add --dev X` is right.

before:
<img width="592" alt="Screenshot 2021-08-06 at 21 41 58" src="https://user-images.githubusercontent.com/100233/128569552-b15a9513-7e14-45f4-bcbb-497f401d8150.png">

after is weirdly still the same? maybe netlify is not rebuilding or something? on node repl, it works fine.