### PR TITLE
fix(custom-navigators): incorrect typing for Props

### DIFF
--- a/versioned_docs/version-6.x/custom-navigators.md
+++ b/versioned_docs/version-6.x/custom-navigators.md
@@ -220,7 +220,12 @@ type TabNavigationEventMap = {
 };
 
 // The props accepted by the component is a combination of 3 things
-type Props = DefaultNavigatorOptions<TabNavigationOptions> &
+type Props = DefaultNavigatorOptions<
+  ParamListBase,
+  TabNavigationState<ParamListBase>,
+  TabNavigationOptions,
+  TabNavigationEventMap
+> &
   TabRouterOptions &
   TabNavigationConfig;
 


### PR DESCRIPTION
I was getting Typescript errors in my custom navigator following an upgrade from a beta version of v6 to `6.0.2`, so I decided to look into the codebase of React Navigation itself. Seems to me like the docs still require updating here.

See [here](https://github.com/react-navigation/react-navigation/blob/2084fb859ffa7c8ce2de859dba777a1227ff05c2/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx#L21) for example in `createBottomTabNavigator`