### PR TITLE
fix: Missing installations for Drawer Based Navigation

### DIFF
--- a/versioned_docs/version-6.x/drawer-based-navigation.md
+++ b/versioned_docs/version-6.x/drawer-based-navigation.md
@@ -18,6 +18,12 @@ Before continuing, first install [`@react-navigation/drawer`](https://github.com
 npm install @react-navigation/drawer
 ```
 
+And install the other required packages [`react-native-gesture-handler`](https://docs.swmansion.com/react-native-gesture-handler/) and [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/) to use Drawer Navigation.
+
+```bash npm2yarn
+npm install react-native-gesture-handler
+npm install react-native-reanimated
+
 ## Minimal example of drawer-based navigation
 
 To use this drawer navigator, import it from `@react-navigation/drawer`:

--- a/versioned_docs/version-6.x/drawer-based-navigation.md
+++ b/versioned_docs/version-6.x/drawer-based-navigation.md
@@ -23,6 +23,7 @@ And install the other required packages [`react-native-gesture-handler`](https:/
 ```bash npm2yarn
 npm install react-native-gesture-handler
 npm install react-native-reanimated
+```
 
 ## Minimal example of drawer-based navigation
 


### PR DESCRIPTION
In the docs there are 2 related Drawer pages and one of them does not contain required packages or routing the related installation package. 

Page 1: https://reactnavigation.org/docs/drawer-based-navigation
Page 2: https://reactnavigation.org/docs/drawer-navigator/