### PR TITLE
docs: add missing renamed options in native-stack

### DIFF
--- a/versioned_docs/version-6.x/upgrading-from-5.x.md
+++ b/versioned_docs/version-6.x/upgrading-from-5.x.md
@@ -462,6 +462,8 @@ If you were importing `createNativeStackNavigator` from `react-native-screens/na
 - `headerTranslucent` is changed to `headerTransparent`
 - `headerBlurEffect` is now a separate option and no longer a property in `headerStyle`
 - `headerTopInsetEnabled` option is removed, it's now automatically set when necessary
+- `backButtonImage` is renamed to `headerBackImageSource`
+- `searchBar` is renamed to `headerSearchBarOptions`
 - `replaceAnimation` is renamed to `animationTypeForReplace`
 - `stackAnimation` is renamed to `animation`
 - `stackPresentation` is renamed to `presentation` - the value `push` is now called `card`


### PR DESCRIPTION
Add missing rename of 
`backButtonImage`->`headerBackImageSource`
`searchBar`->`headerSearchBarOptions` 
 to the upgrade guide of native-stack.