### PR TITLE
feat: add headerBackButtonMenuEnabled prop

### DIFF
--- a/versioned_docs/version-6.x/native-stack-navigator.md
+++ b/versioned_docs/version-6.x/native-stack-navigator.md
@@ -63,6 +63,14 @@ The following [options](screen-options.md) can be used to configure the screens 
 
 String that can be used as a fallback for `headerTitle`.
 
+#### `headerBackButtonMenuEnabled`
+
+Boolean indicating whether to show the menu on longPress of iOS >= 14 back button. Defaults to `true`.
+
+Requires `react-native-screens` version >=3.3.0.
+
+Only supported on iOS.
+
 #### `headerBackVisible`
 
 Whether the back button is visible in the header. You can use it to show a back button alongside `headerLeft` if you have specified it.

--- a/versioned_docs/version-6.x/upgrading-from-5.x.md
+++ b/versioned_docs/version-6.x/upgrading-from-5.x.md
@@ -462,6 +462,7 @@ If you were importing `createNativeStackNavigator` from `react-native-screens/na
 - `headerTranslucent` is changed to `headerTransparent`
 - `headerBlurEffect` is now a separate option and no longer a property in `headerStyle`
 - `headerTopInsetEnabled` option is removed, it's now automatically set when necessary
+- `disableBackButtonMenu` is changed to `headerBackButtonMenuEnabled`
 - `backButtonImage` is renamed to `headerBackImageSource`
 - `searchBar` is renamed to `headerSearchBarOptions`
 - `replaceAnimation` is renamed to `animationTypeForReplace`


### PR DESCRIPTION
Follow up to adding `headerBackButtonMenuEnabled` prop to `@react-navigation/native-stack` in https://github.com/react-navigation/react-navigation/pull/9881