### PR TITLE
fix: renamed createStackNavigator to createNativeStackNavigator

### DIFF
--- a/versioned_docs/version-6.x/native-stack-navigator.md
+++ b/versioned_docs/version-6.x/native-stack-navigator.md
@@ -511,9 +511,9 @@ navigation.popToTop();
 ## Example
 
 ```js
-import { createStackNavigator } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
-const Stack = createStackNavigator();
+const Stack = createNativeStackNavigator();
 
 function MyStack() {
   return (


### PR DESCRIPTION
Documentation was refering to `createStackNavigator` function instead of `createNativeStackNavigator`