### PR TITLE
 clarify meaning of current screen for transition events

### DIFF
--- a/versioned_docs/version-6.x/stack-navigator.md
+++ b/versioned_docs/version-6.x/stack-navigator.md
@@ -336,7 +336,7 @@ The navigator can [emit events](navigation-events.md) on certain actions. Suppor
 
 #### `transitionStart`
 
-This event is fired when the transition animation starts for the current screen.
+This event is fired when the transition animation starts for a screen with a listener registered.
 
 Event data:
 
@@ -356,7 +356,7 @@ React.useEffect(() => {
 
 #### `transitionEnd`
 
-This event is fired when the transition animation ends for the current screen.
+This event is fired when the transition animation ends for for a screen with a listener registered.
 
 Event data:
 


### PR DESCRIPTION
clarify meaning of current screen for stack navigator transition events.
See 
https://github.com/react-navigation/react-navigation/pull/9915
