### PR TITLE
Code of screen tracking example

### DIFF
--- a/versioned_docs/version-6.x/screen-tracking.md
+++ b/versioned_docs/version-6.x/screen-tracking.md
@@ -39,14 +39,14 @@ export default () => {
         const currentRouteName = navigationRef.getCurrentRoute().name;
 
         if (previousRouteName !== currentRouteName) {
+          // Save the current route name for later comparison
+          routeNameRef.current = currentRouteName;
+          
           // The line below uses the expo-firebase-analytics tracker
           // https://docs.expo.io/versions/latest/sdk/firebase-analytics/
           // Change this line to use another Mobile analytics SDK
           await Analytics.setCurrentScreen(currentRouteName);
         }
-
-        // Save the current route name for later comparison
-        routeNameRef.current = currentRouteName;
       }}
     >
       {/* ... */}


### PR DESCRIPTION
We used this code on my project, but we had a bug: on some screens, analytics were not sent. 

We used the fix I propose in this PR:`routeNameRef.current` has to be updated **before**  the analytic is sent. If we do it *after*, the user has the time to navigate to a new screen during the time the analytic is sent. But it will be undetected, because previousRouteName would not have been updated already. 

We also can move this line in the "if" block because if they are identical, we don't need to update the reference.

An other solution to achieve the same result is to delete the "await" before Analytics.setCurrentScreen. But I find it more confusing: we "hide" the fact that sending analytics is asynchronous. Especially if some action has to be performed after.

# OK read 
No `screen-tracking.md` file exists. Only the versioned file has been modified. 