### PR TITLE
fix(issue #1038) Dead link in documentation(headers)

### DIFF
--- a/versioned_docs/version-6.x/headers.md
+++ b/versioned_docs/version-6.x/headers.md
@@ -166,7 +166,7 @@ function StackScreen() {
       <Stack.Screen
         name="Home"
         component={HomeScreen}
-        options={{ headerTitle: props => <LogoTitle {...props} /> }}
+        options={{ headerTitle: (props) => <LogoTitle {...props} /> }}
       />
     </Stack.Navigator>
   );
@@ -177,10 +177,10 @@ function StackScreen() {
 
 ## Additional configuration
 
-You can read the full list of available `options` for screens inside of a native stack navigator in the [`createNativeStackNavigator` reference](native-stack-navigator#options).
+You can read the full list of available `options` for screens inside of a native stack navigator in the [`createNativeStackNavigator` reference](native-stack-navigator.md#options).
 
 ## Summary
 
-- You can customize the header inside of the `options` prop of your screen components. Read the full list of options [in the API reference](native-stack-navigator#options).
+- You can customize the header inside of the `options` prop of your screen components. Read the full list of options [in the API reference](native-stack-navigator.md#options).
 - The `options` prop can be an object or a function. When it is a function, it is provided with an object with the `navigation` and `route` prop.
 - You can also specify shared `screenOptions` in the stack navigator configuration when you initialize it. The prop takes precedence over that configuration.


### PR DESCRIPTION
# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
