### PR TITLE
Fix testing.md with correct path for silencing useNativeDriver

### DIFF
--- a/versioned_docs/version-6.x/testing.md
+++ b/versioned_docs/version-6.x/testing.md
@@ -29,7 +29,7 @@ jest.mock('react-native-reanimated', () => {
 });
 
 // Silence the warning: Animated: `useNativeDriver` is not supported because the native animated module is missing
-jest.mock('react-native/Libraries/Animated/src/NativeAnimatedHelper');
+jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper');
 ```
 
 Then we need to use this setup file in our jest config. You can add it under `setupFiles` option in a `jest.config.js` file or the `jest` key in `package.json`:


### PR DESCRIPTION
Current path in `testing.md` for silencing the Animated warning for useNativeDriver is incorrect.
This PR fixes that path!