### PR TITLE
fix: change channel name for discord

### DIFF
--- a/src/pages/help.js
+++ b/src/pages/help.js
@@ -14,7 +14,7 @@ export default function Help () {
       title: <p>Browse Docs and API</p>,
     },
     {
-      content: <p>Ask questions about the documentation and project in the `#react-navigation` channel on the <Link to={useBaseUrl('https://discord.gg/reactiflux')}> Reactiflux Discord</Link>.</p>,
+      content: <p>Ask questions about the documentation and project in the `#help-react-native` channel on the <Link to={useBaseUrl('https://discord.gg/reactiflux')}> Reactiflux Discord</Link>.</p>,
       title: <p>Join the community</p>,
     },
     {


### PR DESCRIPTION
Upon joining I noticed the channel is archived and has been merged into #help-react-native.

I've read the read-me but I don't understand the instructions. So if this pr is wrong feel free to think of it as an issue instead.