### PR TITLE
fix: `npm2yarn` conversion of `--save-dev` install option

### DIFF
--- a/src/plugins/remark-npm2yarn/index.js
+++ b/src/plugins/remark-npm2yarn/index.js
@@ -15,6 +15,8 @@ const convertNpmToYarn = npmCode => {
       .replace(/^npm i$/gm, 'yarn')
       // install: 'npm install foo' -> 'yarn add foo'
       .replace(/npm install/gm, 'yarn add')
+      // install: 'npm install --save-dev foo' -> 'yarn add --dev foo'
+      .replace(/npm install --save-dev/gm, 'yarn add --dev')
       // run command: 'npm run start' -> 'yarn run start'
       .replace(/npm run/gm, 'yarn run')
   );


### PR DESCRIPTION
On https://reactnavigation.org/docs/devtools/#useflipper the command `npm install --save-dev react-native-flipper` is being converted to `yarn add --save-dev react-native-flipper` which is wrong because `--save-dev` is invalid in yarn and should instead be `--dev`.
