### PR TITLE
Provide correct link to the Flipper setup guide

### DIFF
--- a/versioned_docs/version-6.x/devtools.md
+++ b/versioned_docs/version-6.x/devtools.md
@@ -26,7 +26,7 @@ This hook provides integration with [Flipper](https://fbflipper.com/) for React 
 
 To be able to use this hook, you need to:
 
-- [Configure Flipper in your React Native app](https://fbflipper.com/docs/features/react-native/) if it's not configured already
+- [Configure Flipper in your React Native app](https://fbflipper.com/docs/getting-started/react-native/) if it's not configured already
 - Install the `react-native-flipper` package in your app:
 
   ```bash npm2yarn


### PR DESCRIPTION
The old link pointed to https://fbflipper.com/docs/features/react-native/ which seems to describe 3rd-party plugin integration with Flipper.

At the same time, the new link https://fbflipper.com/docs/getting-started/react-native/ describes how to "Set up your React Native App".

