### PR TITLE
Fix grammar in v5 and v6 of params.md

### DIFF
--- a/versioned_docs/version-5.x/params.md
+++ b/versioned_docs/version-5.x/params.md
@@ -161,7 +161,7 @@ See [Nesting navigators](nesting-navigators.md) for more details on nesting.
 
 ## What should be in params
 
-It's important to understand what kind of data should be in params. Params are like options for a screen. They should only contain information to configure what's displayed in the screen. Avoid passing the full data which will be displayed on the screen itself (e.g. pass an user id instead of user object). Also avoid passing data which is used by multiple screens, such data should be in a global store.
+It's important to understand what kind of data should be in params. Params are like options for a screen. They should only contain information to configure what's displayed in the screen. Avoid passing the full data which will be displayed on the screen itself (e.g. pass a user id instead of user object). Also avoid passing data which is used by multiple screens, such data should be in a global store.
 
 You can also think of the route object like a URL. If your screen had a URL, what should be in the URL? Params shouldn't contain data that you think should not be in the URL. This often means that you should keep as little data as possible needed to determine what the screen is. Think of visiting a shopping website, when you are seeing product listings, the URL usually contains category name, type of sort, any filters etc., it doesn't contain the actual list of products displayed on the screen.
 

--- a/versioned_docs/version-6.x/params.md
+++ b/versioned_docs/version-6.x/params.md
@@ -161,7 +161,7 @@ See [Nesting navigators](nesting-navigators.md) for more details on nesting.
 
 ## What should be in params
 
-It's important to understand what kind of data should be in params. Params are like options for a screen. They should only contain information to configure what's displayed in the screen. Avoid passing the full data which will be displayed on the screen itself (e.g. pass an user id instead of user object). Also avoid passing data which is used by multiple screens, such data should be in a global store.
+It's important to understand what kind of data should be in params. Params are like options for a screen. They should only contain information to configure what's displayed in the screen. Avoid passing the full data which will be displayed on the screen itself (e.g. pass a user id instead of user object). Also avoid passing data which is used by multiple screens, such data should be in a global store.
 
 You can also think of the route object like a URL. If your screen had a URL, what should be in the URL? Params shouldn't contain data that you think should not be in the URL. This often means that you should keep as little data as possible needed to determine what the screen is. Think of visiting a shopping website, when you are seeing product listings, the URL usually contains category name, type of sort, any filters etc., it doesn't contain the actual list of products displayed on the screen.
 


### PR DESCRIPTION
# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:

--- 

Hey there,

I am following along in some of the React Navigation docs, and noticed a grammar error. The `params.md` file of Docs version 5 and 6 were using `an user id` instead of `a user id`. This PR fixes that grammar in both of those files. It was not present in earlier versions. 

Files changed: 

* `/versioned_docs/version-4.x/params.md`
* `/versioned_docs/version-4.x/params.md`

Thanks!