### PR TITLE
fix: `tabBar` component example

### DIFF
--- a/versioned_docs/version-6.x/bottom-tab-navigator.md
+++ b/versioned_docs/version-6.x/bottom-tab-navigator.md
@@ -109,7 +109,7 @@ function MyTabBar({ state, descriptors, navigation }) {
 
           if (!isFocused && !event.defaultPrevented) {
             // The `merge: true` option makes sure that the params inside the tab screen are preserved
-            navigation.navigate({ name: route.name, merge: true });
+            navigation.navigate(route.name, { merge: true });
           }
         };
 


### PR DESCRIPTION
the current example is passing a wrong type of argument to the `navigate` method.
