### PR TITLE
fix: prevent-going-back snack crash

### DIFF
--- a/static/examples/6.x/prevent-going-back.js
+++ b/static/examples/6.x/prevent-going-back.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Alert, View, TextEditText, StyleSheet } from 'react-native';
+import { Alert, View, TextInput, StyleSheet } from 'react-native';
 import { Button } from 'react-native-paper';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
@@ -37,7 +37,7 @@ const EditTextScreen = ({ navigation }) => {
 
   return (
     <View style={styles.content}>
-      <TextEditText
+      <TextInput
         autoFocus
         style={styles.input}
         value={text}


### PR DESCRIPTION
## Description

An incorrect component import in a `prevent-going-back` Snack leads to a crash.

Changing `TextEditText` ➡️  `TextInput` fixes the problem.

## Before

<img src="https://user-images.githubusercontent.com/39658211/154223990-881adf7b-4a3e-45c9-9c54-2d88aa166e48.PNG" width="350px" />

## After

<img src="https://user-images.githubusercontent.com/39658211/154224023-e1ebab7c-69a6-43a0-a6d7-b45bf282328e.PNG" width="350px" />


