### PR TITLE
fix: HeaderBackButton usage in elements.md

### DIFF
--- a/versioned_docs/version-6.x/elements.md
+++ b/versioned_docs/version-6.x/elements.md
@@ -200,7 +200,7 @@ A component used to show the back button header. It's the default for [`headerLe
 Usage:
 
 ```js
-<HeaderTitle>Hello</HeaderTitle>
+<HeaderBackButton label="Hello" />
 ```
 
 ### `MissingIcon`


### PR DESCRIPTION
This PR fixes a copy-paste mistake in the `HeaderBackButton` section.

Fixes https://github.com/react-navigation/react-navigation.github.io/issues/971