### PR TITLE
Add missing screenOptions to Tab.Navigator

### DIFF
--- a/versioned_docs/version-6.x/tab-based-navigation.md
+++ b/versioned_docs/version-6.x/tab-based-navigation.md
@@ -219,7 +219,7 @@ const Tab = createBottomTabNavigator();
 export default function App() {
   return (
     <NavigationContainer>
-      <Tab.Navigator>
+      <Tab.Navigator screenOptions={{ headerShown: false }}>
         <Tab.Screen name="Home" component={HomeStackScreen} />
         <Tab.Screen name="Settings" component={SettingsStackScreen} />
       </Tab.Navigator>


### PR DESCRIPTION
When I copied the code from "A native stack navigator for each tab", I realized the header is being duplicated. I checked that in the snack version, there is this "screenOptions" which is missing in the docs. I added it now.

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
