### PR TITLE
docs: Use message.data instead of message.notification for Firebase Cloud Messaging

### DIFF
--- a/versioned_docs/version-6.x/navigation-container.md
+++ b/versioned_docs/version-6.x/navigation-container.md
@@ -358,6 +358,8 @@ You can provide a custom `getInitialURL` function where you can return the link 
 For example, you could do something like following to handle both deep linking and [Firebase notifications](https://rnfirebase.io/messaging/notifications):
 
 ```js
+import messaging from '@react-native-firebase/messaging';
+
 <NavigationContainer
   linking={{
     prefixes: ['https://mychat.com', 'mychat://'],
@@ -396,6 +398,8 @@ Similar to [`getInitialURL`](#linkinggetinitialurl), you can provide a custom `s
 For example, you could do something like following to handle both deep linking and [Firebase notifications](https://rnfirebase.io/messaging/notifications):
 
 ```js
+import messaging from '@react-native-firebase/messaging';
+
 <NavigationContainer
   linking={{
     prefixes: ['https://mychat.com', 'mychat://'],

--- a/versioned_docs/version-6.x/navigation-container.md
+++ b/versioned_docs/version-6.x/navigation-container.md
@@ -379,7 +379,7 @@ For example, you could do something like following to handle both deep linking a
 
       // Get the `url` property from the notification which corresponds to a screen
       // This property needs to be set on the notification payload when sending it
-      return message?.data.url;
+      return message?.data?.url;
     },
   }}
 >
@@ -413,7 +413,7 @@ For example, you could do something like following to handle both deep linking a
       // Listen to firebase push notifications
       const unsubscribeNotification = messaging().onNotificationOpenedApp(
         (message) => {
-          const url = message.data.url;
+          const url = message.data?.url;
 
           if (url) {
             // Any custom logic to check whether the URL needs to be handled

--- a/versioned_docs/version-6.x/navigation-container.md
+++ b/versioned_docs/version-6.x/navigation-container.md
@@ -408,7 +408,7 @@ For example, you could do something like following to handle both deep linking a
       const onReceiveURL = ({ url }: { url: string }) => listener(url);
 
       // Listen to incoming links from deep linking
-      Linking.addEventListener('url', onReceiveURL);
+      const subscription = Linking.addEventListener('url', onReceiveURL);
 
       // Listen to firebase push notifications
       const unsubscribeNotification = messaging().onNotificationOpenedApp(
@@ -427,7 +427,7 @@ For example, you could do something like following to handle both deep linking a
 
       return () => {
         // Clean up the event listeners
-        Linking.removeEventListener('url', onReceiveURL);
+        subscription.remove();
         unsubscribeNotification();
       };
     },

--- a/versioned_docs/version-6.x/navigation-container.md
+++ b/versioned_docs/version-6.x/navigation-container.md
@@ -379,7 +379,7 @@ For example, you could do something like following to handle both deep linking a
 
       // Get the `url` property from the notification which corresponds to a screen
       // This property needs to be set on the notification payload when sending it
-      return message?.notification.url;
+      return message?.data.url;
     },
   }}
 >
@@ -413,7 +413,7 @@ For example, you could do something like following to handle both deep linking a
       // Listen to firebase push notifications
       const unsubscribeNotification = messaging().onNotificationOpenedApp(
         (message) => {
-          const url = message.notification.url;
+          const url = message.data.url;
 
           if (url) {
             // Any custom logic to check whether the URL needs to be handled


### PR DESCRIPTION
- Use data instead of notification

    [Notification](https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#notification) does not support `url` property.

- Use optional chaining operators more precisely

- Replace Linking.removeEventListener

    `Linking.removeEventListener` is deprecated.

    See: https://reactnative.dev/docs/next/linking#removeeventlistener

- Add @react-native-firebase/messaging imports