### PR TITLE
docs: update link text

### DIFF
--- a/versioned_docs/version-5.x/tab-actions.md
+++ b/versioned_docs/version-5.x/tab-actions.md
@@ -4,7 +4,7 @@ title: TabActions reference
 sidebar_label: TabActions
 ---
 
-`TabActions` is an object containing methods for generating actions specific to tab-based navigators. Its methods expand upon the actions available in [`NavigationActions`](navigation-actions.md).
+`TabActions` is an object containing methods for generating actions specific to tab-based navigators. Its methods expand upon the actions available in [`CommonActions`](navigation-actions.md).
 
 The following actions are supported:
 

--- a/versioned_docs/version-6.x/tab-actions.md
+++ b/versioned_docs/version-6.x/tab-actions.md
@@ -4,7 +4,7 @@ title: TabActions reference
 sidebar_label: TabActions
 ---
 
-`TabActions` is an object containing methods for generating actions specific to tab-based navigators. Its methods expand upon the actions available in [`NavigationActions`](navigation-actions.md).
+`TabActions` is an object containing methods for generating actions specific to tab-based navigators. Its methods expand upon the actions available in [`CommonActions`](navigation-actions.md).
 
 The following actions are supported:
 


### PR DESCRIPTION
This pr updates the link text `NavigationActions` to `CommonActions` in `TabActions` to be consistent across other `Action` page. `StackActions` and `DrawerActions` has the same content with `CommonActions` as link text.