### PR TITLE
Change migration guide url and text

### DIFF
--- a/src/pages/home/Splash/index.js
+++ b/src/pages/home/Splash/index.js
@@ -41,12 +41,12 @@ export default function Splash() {
         <SplashRightIllustration />
       </div>
       <div className={styles.migrationText}>
-        💡 Coming from v4? Check out our{' '}
+        💡 Coming from v5? Check out our{' '}
         <Link
-          to={useBaseUrl('/docs/5.x/upgrading-from-4.x')}
+          to={useBaseUrl('/docs/upgrading-from-5.x')}
           className={styles.linkText}
         >
-          v4 to v5 migration guide
+          v5 to v6 migration guide
         </Link>
         .
       </div>


### PR DESCRIPTION
## Change the text and url of the migration guide on the Splash screen. 

Current: upgrade from **v4** to **v5**
Changes: upgrade from **v5** to **v6**