### PR TITLE
Update deep-linking.md

### DIFF
--- a/versioned_docs/version-6.x/deep-linking.md
+++ b/versioned_docs/version-6.x/deep-linking.md
@@ -173,6 +173,11 @@ After adding them, it should look like this:
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
         <data android:scheme="mychat" />
+    </intent-filter>
+    <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
         <data android:scheme="http" />
         <data android:scheme="https" />
         <data android:host="www.example.com" />

--- a/versioned_docs/version-6.x/deep-linking.md
+++ b/versioned_docs/version-6.x/deep-linking.md
@@ -173,8 +173,9 @@ After adding them, it should look like this:
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
         <data android:scheme="mychat" />
-        <data android:scheme="https" android:host="www.example.com" />
-        <data android:scheme="http" android:host="www.example.com" />
+        <data android:scheme="http" />
+        <data android:scheme="https" />
+        <data android:host="www.example.com" />
     </intent-filter>
 </activity>
 ```


### PR DESCRIPTION
According to official docs (https://developer.android.com/training/app-links/verify-site-associations), the scheme and host should be defined in separate `data` tags. Initially I followed the current doc, but after doing some search I found out that combining the `scheme` and `host` into one `data` broke the universal links in Android.
