### PR TITLE
Add missing drawer-jump-to example

### DIFF
--- a/static/examples/5.x/drawer-jump-to.js
+++ b/static/examples/5.x/drawer-jump-to.js
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { Text, View, Button } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { createDrawerNavigator } from '@react-navigation/drawer';
+
+function HomeScreen({ navigation }) {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Home!</Text>
+      <Button
+        title="Go to profile"
+        onPress={() => navigation.jumpTo('Profile', { owner: 'Satya' })}
+      />
+    </View>
+  );
+}
+
+function ProfileScreen({ route }) {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Profile!</Text>
+      <Text>
+        {route?.params?.owner ? `${route.params.owner}'s Profile` : ''}
+      </Text>
+    </View>
+  );
+}
+
+const Drawer = createDrawerNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Drawer.Navigator>
+        <Drawer.Screen name="Home" component={HomeScreen} />
+        <Drawer.Screen name="Profile" component={ProfileScreen} />
+      </Drawer.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/static/examples/6.x/drawer-jump-to.js
+++ b/static/examples/6.x/drawer-jump-to.js
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { Text, View, Button } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { createDrawerNavigator } from '@react-navigation/drawer';
+
+function HomeScreen({ navigation }) {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Home!</Text>
+      <Button
+        title="Go to profile"
+        onPress={() => navigation.jumpTo('Profile', { owner: 'Satya' })}
+      />
+    </View>
+  );
+}
+
+function ProfileScreen({ route }) {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Profile!</Text>
+      <Text>
+        {route?.params?.owner ? `${route.params.owner}'s Profile` : ''}
+      </Text>
+    </View>
+  );
+}
+
+const Drawer = createDrawerNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Drawer.Navigator>
+        <Drawer.Screen name="Home" component={HomeScreen} />
+        <Drawer.Screen name="Profile" component={ProfileScreen} />
+      </Drawer.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/versioned_docs/version-5.x/drawer-navigator.md
+++ b/versioned_docs/version-5.x/drawer-navigator.md
@@ -545,7 +545,7 @@ Navigates to an existing screen in the drawer navigator. The method accepts foll
 - `name` - _string_ - Name of the route to jump to.
 - `params` - _object_ - Screen params to merge into the destination route (found in the pushed screen through `route.params`).
 
-<samp id="drawer-example" />
+<samp id="drawer-jump-to" />
 
 ```js
 navigation.jumpTo('Profile', { owner: 'Satya' });

--- a/versioned_docs/version-6.x/drawer-navigator.md
+++ b/versioned_docs/version-6.x/drawer-navigator.md
@@ -544,7 +544,7 @@ Navigates to an existing screen in the drawer navigator. The method accepts foll
 - `name` - _string_ - Name of the route to jump to.
 - `params` - _object_ - Screen params to pass to the destination route.
 
-<samp id="drawer-example" />
+<samp id="drawer-jump-to" />
 
 ```js
 navigation.jumpTo('Profile', { owner: 'Satya' });


### PR DESCRIPTION
Added a snack for `jumpTo` to both v5 and v6 docs.