### PR TITLE
Fix spelling `let's us` -> `lets us`

### DIFF
--- a/versioned_docs/version-5.x/use-theme.md
+++ b/versioned_docs/version-5.x/use-theme.md
@@ -4,7 +4,7 @@ title: useTheme
 sidebar_label: useTheme
 ---
 
-The `useTheme` hook let's us access the currently active theme. You can use it in your own components to have them respond to changes in the theme.
+The `useTheme` hook lets us access the currently active theme. You can use it in your own components to have them respond to changes in the theme.
 
 <samp id="system-themes" />
 

--- a/versioned_docs/version-6.x/use-theme.md
+++ b/versioned_docs/version-6.x/use-theme.md
@@ -4,7 +4,7 @@ title: useTheme
 sidebar_label: useTheme
 ---
 
-The `useTheme` hook let's us access the currently active theme. You can use it in your own components to have them respond to changes in the theme.
+The `useTheme` hook lets us access the currently active theme. You can use it in your own components to have them respond to changes in the theme.
 
 <samp id="system-themes" />
 


### PR DESCRIPTION
Fixed typos in use-theme.md for both v5.x & v6.x docs.