### PR TITLE
docs: add react-native-wait-navigation

### DIFF
--- a/versioned_docs/version-6.x/navigating-without-navigation-prop.md
+++ b/versioned_docs/version-6.x/navigating-without-navigation-prop.md
@@ -104,3 +104,5 @@ export function navigate(name, params) {
 ```
 
 If you're unsure if a navigator is rendered, you can call `navigationRef.current.getRootState()`, and it'll return a valid state object if any navigators are rendered, otherwise it will return `undefined`.
+
+Or you can check out third party solution [`react-native-wait-navigation`](https://github.com/oktaysenkan/react-native-wait-navigation)


### PR DESCRIPTION
I made new library for handling **react navigation** initialization called **[react-native-wait-navigation](https://github.com/oktaysenkan/react-native-wait-navigation)**. I linked my library on **navigating-without-navigation-prop** page for v6. If this is approved, i can add for every version.