### PR TITLE
docs: update 'coming from' banner

### DIFF
--- a/src/pages/home/Splash/index.js
+++ b/src/pages/home/Splash/index.js
@@ -41,12 +41,12 @@ export default function Splash() {
         <SplashRightIllustration />
       </div>
       <div className={styles.migrationText}>
-        💡 Coming from v5? Check out our{' '}
+        💡 Coming from an older version? Check out our{' '}
         <Link
-          to={useBaseUrl('/docs/upgrading-from-5.x')}
+          to={useBaseUrl('/docs/migration-guides')}
           className={styles.linkText}
         >
-          v5 to v6 migration guide
+          migration guides
         </Link>
         .
       </div>

--- a/src/pages/home/Splash/index.js
+++ b/src/pages/home/Splash/index.js
@@ -41,12 +41,12 @@ export default function Splash() {
         <SplashRightIllustration />
       </div>
       <div className={styles.migrationText}>
-        💡 Coming from v4? Check out our{' '}
+        💡 Coming from v5? Check out our{' '}
         <Link
-          to={useBaseUrl('/docs/5.x/upgrading-from-4.x')}
+          to={useBaseUrl('/docs/upgrading-from-5.x')}
           className={styles.linkText}
         >
-          v4 to v5 migration guide
+          v5 to v6 migration guide
         </Link>
         .
       </div>

--- a/versioned_docs/version-6.x/migration-guides.md
+++ b/versioned_docs/version-6.x/migration-guides.md
@@ -1,14 +1,15 @@
 ---
 id: migration-guides
 title: Migration Guides
+sidebar_label: Migration Guides
 ---
 
 # Migration guides
 
-This page contains links to pages that will painlessly guide you through the process of upgrading React Navigation. Sadly, if you are upgrading from older versions, you will have to sequentially update the versions one by one to the desired state.
+This page contains links to pages that will painlessly guide you through the process of upgrading React Navigation:
 
 - [Upgrading from 5.x to 6.x](upgrading-from-5.x.md)
 - [Upgrading from 4.x to 5.x](../version-5.x/upgrading-from-4.x.md)
 - [Upgrading from 3.x to 4.x](../version-4.x/upgrading-from-3.x.md)
 
-Navigated to this page by a mistake? Start learning React Navigation [from the start](getting-started.md).
+Sadly, if you are upgrading from older versions, you will have to sequentially update the versions one by one to the desired state.

--- a/versioned_docs/version-6.x/migration-guides.md
+++ b/versioned_docs/version-6.x/migration-guides.md
@@ -1,0 +1,14 @@
+---
+id: migration-guides
+title: Migration Guides
+---
+
+# Migration guides
+
+This page contains links to pages that will painlessly guide you through the process of upgrading React Navigation. Sadly, if you are upgrading from older versions, you will have to sequentially update the versions one by one to the desired state.
+
+- [Upgrading from 5.x to 6.x](upgrading-from-5.x.md)
+- [Upgrading from 4.x to 5.x](../version-5.x/upgrading-from-4.x.md)
+- [Upgrading from 3.x to 4.x](../version-4.x/upgrading-from-3.x.md)
+
+Navigated to this page by a mistake? Start learning React Navigation [from the start](getting-started.md).

--- a/versioned_sidebars/version-6.x-sidebars.json
+++ b/versioned_sidebars/version-6.x-sidebars.json
@@ -100,6 +100,7 @@
       "version-6.x/custom-navigators"
     ],
     "Additional Resources": [
+      "version-6.x/migration-guides",
       "version-6.x/community-libraries-and-navigators",
       "version-6.x/more-resources"
     ],


### PR DESCRIPTION
Update landing page to show migration guide from v5 to v6 by default.