### PR TITLE
Use existing icon in example for Tab Navigation

### DIFF
--- a/versioned_docs/version-6.x/tab-based-navigation.md
+++ b/versioned_docs/version-6.x/tab-based-navigation.md
@@ -80,7 +80,7 @@ export default function App() {
                 ? 'ios-information-circle'
                 : 'ios-information-circle-outline';
             } else if (route.name === 'Settings') {
-              iconName = focused ? 'ios-list-box' : 'ios-list';
+              iconName = focused ? 'ios-list' : 'ios-list-outline';
             }
 
             // You can return any component that you like here!


### PR DESCRIPTION
# Info

There is no `ios-list-box` icon in `react-native-vector-icons/Ionicons` icon set. You can check it using https://oblador.github.io/react-native-vector-icons/

That's why using `ios-list` and `ios-list-outline` much more better. 