### PR TITLE
changed file extension from .tsx to .ts for types file

### DIFF
--- a/versioned_docs/version-6.x/typescript.md
+++ b/versioned_docs/version-6.x/typescript.md
@@ -137,7 +137,7 @@ import type { RouteProp } from '@react-navigation/native';
 type ProfileScreenRouteProp = RouteProp<RootStackParamList, 'Profile'>;
 ```
 
-We recommend creating a separate `types.tsx` file where you keep the types and import them in your component files instead of repeating them in each file.
+We recommend creating a separate `types.ts` file where you keep the types and import them in your component files instead of repeating them in each file.
 
 ### Nesting navigators
 
@@ -311,7 +311,7 @@ Specifying this type is important if you heavily use `useNavigation`, `Link` etc
 
 When writing types for React Navigation, there are a couple of things we recommend to keep things organized.
 
-1. It's good to create a separate files (e.g. `navigation/types.tsx`) which contains the types related to React Navigation.
+1. It's good to create a separate files (e.g. `navigation/types.ts`) which contains the types related to React Navigation.
 2. Instead of using `CompositeNavigationProp` directly in your components, it's better to create a helper type that you can reuse.
 3. Specifying a global type for your root navigator would avoid manual annotations in many places.
 


### PR DESCRIPTION
.tsx files should only be used for react components containing jsx, while .ts files should be for functions, types etc.

in this case, the `types` file will only contain types for the navigation.