### PR TITLE
docs: fixes component name in Navigating to a screen in a nested navi…

### DIFF
--- a/versioned_docs/version-6.x/nesting-navigators.md
+++ b/versioned_docs/version-6.x/nesting-navigators.md
@@ -127,7 +127,7 @@ function App() {
           component={Root}
           options={{ headerShown: false }}
         />
-        <Stack.Screen name="Feed" component={Settings} />
+        <Stack.Screen name="Feed" component={Feed} />
       </Stack.Navigator>
     </NavigationContainer>
   );


### PR DESCRIPTION
Changed component name from `Settings` to `Feed` since screen name is `Feed` and the component referred as `Feed` in the text below.