### PR TITLE
docs: update Screen Tracking example to remove expo-firebase-analytics

### DIFF
--- a/static/examples/5.x/screen-tracking-for-analytics.js
+++ b/static/examples/5.x/screen-tracking-for-analytics.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { View, Button } from 'react-native';
-// import * as Analytics from 'expo-firebase-analytics';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 
@@ -32,20 +31,19 @@ export default function App() {
   return (
     <NavigationContainer
       ref={navigationRef}
-      onReady={() => routeNameRef.current = navigationRef.current.getCurrentRoute().name}
+      onReady={() =>
+        (routeNameRef.current = navigationRef.current.getCurrentRoute().name)
+      }
       onStateChange={() => {
         const previousRouteName = routeNameRef.current;
-        const currentRouteName = navigationRef.current.getCurrentRoute().name
+        const currentRouteName = navigationRef.current.getCurrentRoute().name;
 
         if (previousRouteName !== currentRouteName) {
-          // The line below uses the expo-firebase-analytics tracker
-          // https://docs.expo.io/versions/latest/sdk/firebase-analytics/
-          // Change this line to use another Mobile analytics SDK
-          // Analytics.setCurrentScreen(currentRouteName, currentRouteName);
+          // Replace the line below to add the tracker from a mobile analytics SDK
           alert(`The route changed to ${currentRouteName}`);
         }
 
-        // Save the current route name for later comparision
+        // Save the current route name for later comparison
         routeNameRef.current = currentRouteName;
       }}
     >

--- a/static/examples/6.x/screen-tracking-for-analytics.js
+++ b/static/examples/6.x/screen-tracking-for-analytics.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { View, Button } from 'react-native';
-// import * as Analytics from 'expo-firebase-analytics';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 
@@ -40,14 +39,11 @@ export default function App() {
         const currentRouteName = navigationRef.current.getCurrentRoute().name;
 
         if (previousRouteName !== currentRouteName) {
-          // The line below uses the expo-firebase-analytics tracker
-          // https://docs.expo.io/versions/latest/sdk/firebase-analytics/
-          // Change this line to use another Mobile analytics SDK
-          // Analytics.setCurrentScreen(currentRouteName, currentRouteName);
+          // Replace the line below to add the tracker from a mobile analytics SDK
           alert(`The route changed to ${currentRouteName}`);
         }
 
-        // Save the current route name for later comparision
+        // Save the current route name for later comparison
         routeNameRef.current = currentRouteName;
       }}
     >

--- a/versioned_docs/version-5.x/screen-tracking.md
+++ b/versioned_docs/version-5.x/screen-tracking.md
@@ -32,6 +32,11 @@ export default () => {
       onStateChange={async () => {
         const previousRouteName = routeNameRef.current;
         const currentRouteName = navigationRef.current.getCurrentRoute().name;
+        const tracker = {
+          trackScreenView: () => {
+            // Your implementation of analytics goes here!
+          };
+        }
 
         if (previousRouteName !== currentRouteName) {
           // Replace the line below to add the tracker from a mobile analytics SDK

--- a/versioned_docs/version-5.x/screen-tracking.md
+++ b/versioned_docs/version-5.x/screen-tracking.md
@@ -32,15 +32,13 @@ export default () => {
       onStateChange={async () => {
         const previousRouteName = routeNameRef.current;
         const currentRouteName = navigationRef.current.getCurrentRoute().name;
-        const tracker = {
-          trackScreenView: () => {
-            // Your implementation of analytics goes here!
-          };
-        }
+        const trackScreenView = () => {
+          // Your implementation of analytics goes here!
+        };
 
         if (previousRouteName !== currentRouteName) {
           // Replace the line below to add the tracker from a mobile analytics SDK
-          await tracker.trackScreenView(currentRouteName);
+          await trackScreenView(currentRouteName);
         }
 
         // Save the current route name for later comparison

--- a/versioned_docs/version-5.x/screen-tracking.md
+++ b/versioned_docs/version-5.x/screen-tracking.md
@@ -15,6 +15,8 @@ To get notified of state changes, we can use the `onStateChange` prop on `Naviga
 
 This example shows how the approach can be adapted to any mobile analytics SDK.
 
+<samp id="screen-tracking-for-analytics" />
+
 ```js
 import { useRef } from 'react';
 import { NavigationContainer } from '@react-navigation/native';

--- a/versioned_docs/version-5.x/screen-tracking.md
+++ b/versioned_docs/version-5.x/screen-tracking.md
@@ -13,12 +13,9 @@ To get notified of state changes, we can use the `onStateChange` prop on `Naviga
 
 ## Example
 
-This example shows how to do screen tracking and send to Firebase Analytics using [expo-firebase-analytics](https://docs.expo.io/versions/latest/sdk/firebase-analytics/). The approach can be adapted to any other analytics SDK.
-
- <samp id="screen-tracking-for-analytics" />
+This example shows how the approach can be adapted to any mobile analytics SDK.
 
 ```js
-import * as Analytics from 'expo-firebase-analytics';
 import { useRef } from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 
@@ -37,10 +34,8 @@ export default () => {
         const currentRouteName = navigationRef.current.getCurrentRoute().name;
 
         if (previousRouteName !== currentRouteName) {
-          // The line below uses the expo-firebase-analytics tracker
-          // https://docs.expo.io/versions/latest/sdk/firebase-analytics/
-          // Change this line to use another Mobile analytics SDK
-          await Analytics.setCurrentScreen(currentRouteName);
+          // Replace the line below to add the tracker from a mobile analytics SDK
+          await tracker.trackScreenView(currentRouteName);
         }
 
         // Save the current route name for later comparison
@@ -51,5 +46,4 @@ export default () => {
     </NavigationContainer>
   );
 };
-
 ```

--- a/versioned_docs/version-6.x/screen-tracking.md
+++ b/versioned_docs/version-6.x/screen-tracking.md
@@ -34,6 +34,11 @@ export default () => {
       onStateChange={async () => {
         const previousRouteName = routeNameRef.current;
         const currentRouteName = navigationRef.getCurrentRoute().name;
+        const tracker = {
+          trackScreenView: () => {
+            // Your implementation of analytics goes here!
+          };
+        }
 
         if (previousRouteName !== currentRouteName) {
           // Replace the line below to add the tracker from a mobile analytics SDK

--- a/versioned_docs/version-6.x/screen-tracking.md
+++ b/versioned_docs/version-6.x/screen-tracking.md
@@ -13,12 +13,9 @@ To get notified of state changes, we can use the `onStateChange` prop on `Naviga
 
 ## Example
 
-This example shows how to do screen tracking and send to Firebase Analytics using [expo-firebase-analytics](https://docs.expo.io/versions/latest/sdk/firebase-analytics/). The approach can be adapted to any other analytics SDK.
-
- <samp id="screen-tracking-for-analytics" />
+This example shows how the approach can be adapted to any mobile analytics SDK.
 
 ```js
-import * as Analytics from 'expo-firebase-analytics';
 import {
   NavigationContainer,
   useNavigationContainerRef,
@@ -39,10 +36,8 @@ export default () => {
         const currentRouteName = navigationRef.getCurrentRoute().name;
 
         if (previousRouteName !== currentRouteName) {
-          // The line below uses the expo-firebase-analytics tracker
-          // https://docs.expo.io/versions/latest/sdk/firebase-analytics/
-          // Change this line to use another Mobile analytics SDK
-          await Analytics.setCurrentScreen(currentRouteName);
+          // Replace the line below to add the tracker from a mobile analytics SDK
+          await tracker.trackScreenView(currentRouteName);
         }
 
         // Save the current route name for later comparison

--- a/versioned_docs/version-6.x/screen-tracking.md
+++ b/versioned_docs/version-6.x/screen-tracking.md
@@ -15,6 +15,8 @@ To get notified of state changes, we can use the `onStateChange` prop on `Naviga
 
 This example shows how the approach can be adapted to any mobile analytics SDK.
 
+<samp id="screen-tracking-for-analytics" />
+
 ```js
 import {
   NavigationContainer,
@@ -34,15 +36,13 @@ export default () => {
       onStateChange={async () => {
         const previousRouteName = routeNameRef.current;
         const currentRouteName = navigationRef.getCurrentRoute().name;
-        const tracker = {
-          trackScreenView: () => {
-            // Your implementation of analytics goes here!
-          };
-        }
+        const trackScreenView = () => {
+          // Your implementation of analytics goes here!
+        };
 
         if (previousRouteName !== currentRouteName) {
           // Replace the line below to add the tracker from a mobile analytics SDK
-          await tracker.trackScreenView(currentRouteName);
+          await trackScreenView(currentRouteName);
         }
 
         // Save the current route name for later comparison


### PR DESCRIPTION
## Why and how

[expo-firebase-analytics](https://docs.expo.dev/versions/latest/sdk/firebase-analytics/) is getting [deprecated](https://github.com/expo/expo/pull/19398). With SDK 47 going to be released soon, we want developers to migrate from it and use any other mobile analytics SDK.

This PR 
- updates remove references to using `expo-firebase-analytics` from the example in Screen Tracking
- adds a placeholder to indicate at which line the analytics function should be added when using the example
- update the verbiage in context to example
- updates version `6.x` docs and changes backported for `5.x`.