### PR TITLE
Typo fix for v5

### DIFF
--- a/versioned_docs/version-5.x/headers.md
+++ b/versioned_docs/version-5.x/headers.md
@@ -142,7 +142,7 @@ function StackScreen() {
 }
 ```
 
-Now, any screen that belongs to the `StackScreen` will have our wonderful branded styles. Surely though, there must be a way to override these options if we need to?
+Now, any screen that belongs to the `Stack.Navigator` will have our wonderful branded styles. Surely though, there must be a way to override these options if we need to?
 
 ## Replacing the title with a custom component
 


### PR DESCRIPTION
I've already fixed this typo for the v6 and my changes were accepted. It was still missing for the v5 (only). Now I'm doing it.
Thank you. 