### PR TITLE
Update Redux Devtools link to new repo

### DIFF
--- a/versioned_docs/version-5.x/redux-integration.md
+++ b/versioned_docs/version-5.x/redux-integration.md
@@ -87,4 +87,4 @@ So our component will look like this:
 
 This is not possible. We don't support it because it's too easy to shoot yourself in the foot and slow down / break your app.
 
-However it's possible to use [`redux-devtools-extension`](https://github.com/zalmoxisus/redux-devtools-extension) to inspect the [navigation state](navigation-state.md) and actions, as well as perform time travel debugging by using the [`devtools` package](devtools.md).
+However it's possible to use [`redux-devtools-extension`](https://github.com/reduxjs/redux-devtools) to inspect the [navigation state](navigation-state.md) and actions, as well as perform time travel debugging by using the [`devtools` package](devtools.md).

--- a/versioned_docs/version-6.x/redux-integration.md
+++ b/versioned_docs/version-6.x/redux-integration.md
@@ -87,4 +87,4 @@ So our component will look like this:
 
 This is not possible. We don't support it because it's too easy to shoot yourself in the foot and slow down / break your app.
 
-However it's possible to use [`redux-devtools-extension`](https://github.com/zalmoxisus/redux-devtools-extension) to inspect the [navigation state](navigation-state.md) and actions, as well as perform time travel debugging by using the [`devtools` package](devtools.md).
+However it's possible to use [`redux-devtools-extension`](https://github.com/reduxjs/redux-devtools) to inspect the [navigation state](navigation-state.md) and actions, as well as perform time travel debugging by using the [`devtools` package](devtools.md).


### PR DESCRIPTION
Per notice on the repo that the previous link went to:
> This repo is no longer the home of the redux-devtools-extension. The new home is https://github.com/reduxjs/redux-devtools. Please file your issues and PRs there.

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
