### PR TITLE
More clarification with location of override

### DIFF
--- a/versioned_docs/version-6.x/getting-started.md
+++ b/versioned_docs/version-6.x/getting-started.md
@@ -68,16 +68,26 @@ npx pod-install ios
 `react-native-screens` package requires one additional configuration step to properly
 work on Android devices. Edit `MainActivity.java` file which is located in `android/app/src/main/java/<your package name>/MainActivity.java`.
 
-Add the following code to the body of `MainActivity` class:
+Add the following override to the body of `MainActivity` class:
 
 ```java
-@Override
-protected void onCreate(Bundle savedInstanceState) {
-  super.onCreate(null);
-}
+public class MainActivity extends ReactActivity {
+    //...code
+   
+    //react-native-screens override
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(null);
+    }
+   
+    public static class MainActivityDelegate extends ReactActivityDelegate {
+        //...code
+    }
 ```
 
-and make sure to add the following import statement at the top of this file below your package statement:
+Ensure you have placed this in the parent MainActivity and not inside the MainActivityDelegate.
+
+Also, make sure to add the following import statement at the top of this file below your package statement:
 
 ```java
 import android.os.Bundle;


### PR DESCRIPTION
Provided more clarification to the location of where the override location should be. This will help users who are experiencing crashes still because they have placed it in the MainAcitivityDelegate and not the parent function.

[rn screens users - #1481](https://github.com/software-mansion/react-native-screens/issues/1481)