### PR TITLE
docs: add tintColor option for headerSearchBarOptions

### DIFF
--- a/versioned_docs/version-6.x/native-stack-navigator.md
+++ b/versioned_docs/version-6.x/native-stack-navigator.md
@@ -285,6 +285,12 @@ The search field background color. By default bar tint color is translucent.
 
 Only supported on iOS.
 
+##### `tintColor`
+
+The color for the cursor caret and cancel button text.
+
+Only supported on iOS.
+
 ##### `cancelButtonText`
 
 The text to be used instead of default `Cancel` button text.


### PR DESCRIPTION
Added missing `tintColor` option for `headerSearchBarOptions`.

`tintColor`: https://github.com/software-mansion/react-native-screens/blob/main/src/types.tsx#L472

**Example**
`tintColor: "#FF0000"`:

<img width="321" alt="image" src="https://user-images.githubusercontent.com/37284154/203457414-e3c5315e-b5e2-42b1-bf6d-e0e73235786a.png">
