### PR TITLE
Fix incorrect wrapping causing 'jumpy' headers

### DIFF
--- a/versioned_docs/version-6.x/getting-started.md
+++ b/versioned_docs/version-6.x/getting-started.md
@@ -94,10 +94,13 @@ Now, we need to wrap the whole app in `NavigationContainer`. Usually you'd do th
 ```js
 import * as React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 export default function App() {
   return (
-    <NavigationContainer>{/* Rest of your app code */}</NavigationContainer>
+    <SafeAreaProvider>
+      <NavigationContainer>{/* Rest of your app code */}</NavigationContainer>
+    </SafeAreaProvider>
   );
 }
 ```

--- a/versioned_docs/version-6.x/hello-react-navigation.md
+++ b/versioned_docs/version-6.x/hello-react-navigation.md
@@ -35,6 +35,7 @@ import * as React from 'react';
 import { View, Text } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 function HomeScreen() {
   return (
@@ -48,11 +49,13 @@ const Stack = createNativeStackNavigator();
 
 function App() {
   return (
-    <NavigationContainer>
-      <Stack.Navigator>
-        <Stack.Screen name="Home" component={HomeScreen} />
-      </Stack.Navigator>
-    </NavigationContainer>
+    <SafeAreaProvider>
+      <NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen name="Home" component={HomeScreen} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </SafeAreaProvider>
   );
 }
 
@@ -88,12 +91,14 @@ const Stack = createNativeStackNavigator();
 
 function App() {
   return (
-    <NavigationContainer>
-      <Stack.Navigator initialRouteName="Home">
-        <Stack.Screen name="Home" component={HomeScreen} />
-        <Stack.Screen name="Details" component={DetailsScreen} />
-      </Stack.Navigator>
-    </NavigationContainer>
+    <SafeAreaProvider>
+      <NavigationContainer>
+        <Stack.Navigator initialRouteName="Home">
+          <Stack.Screen name="Home" component={HomeScreen} />
+          <Stack.Screen name="Details" component={DetailsScreen} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </SafeAreaProvider>
   );
 }
 ```


### PR DESCRIPTION
Fixes issues like #9557 where users aren't explicitly using `react-native-safe-area-context` (but it's a requirement for React Navigation). The onboarding/getting-started docs should exemplify this requirement so we don't get reports and glitchy/jumpy outcomes for apps using the library