### PR TITLE
Add cleanup function to 'prevent going back' examples and docs

### DIFF
--- a/static/examples/5.x/prevent-going-back.js
+++ b/static/examples/5.x/prevent-going-back.js
@@ -9,31 +9,30 @@ const EditTextScreen = ({ navigation }) => {
 
   const hasUnsavedChanges = Boolean(text);
 
-  React.useEffect(
-    () =>
-      navigation.addListener('beforeRemove', (e) => {
-        const action = e.data.action;
-        if (!hasUnsavedChanges) {
-          return;
-        }
+  React.useEffect(() => {
+    const unsubscribe = navigation.addListener('beforeRemove', (e) => {
+      if (!hasUnsavedChanges) {
+        return;
+      }
 
-        e.preventDefault();
+      e.preventDefault();
 
-        Alert.alert(
-          'Discard changes?',
-          'You have unsaved changes. Are you sure to discard them and leave the screen?',
-          [
-            { text: "Don't leave", style: 'cancel', onPress: () => {} },
-            {
-              text: 'Discard',
-              style: 'destructive',
-              onPress: () => navigation.dispatch(action),
-            },
-          ]
-        );
-      }),
-    [hasUnsavedChanges, navigation]
-  );
+      Alert.alert(
+        'Discard changes?',
+        'You have unsaved changes. Are you sure to discard them and leave the screen?',
+        [
+          { text: "Don't leave", style: 'cancel', onPress: () => {} },
+          {
+            text: 'Discard',
+            style: 'destructive',
+            onPress: () => navigation.dispatch(e.data.action),
+          },
+        ]
+      );
+    });
+
+    return unsubscribe;
+  }, [navigation, hasUnsavedChanges]);
 
   return (
     <View style={styles.content}>

--- a/static/examples/6.x/prevent-going-back.js
+++ b/static/examples/6.x/prevent-going-back.js
@@ -9,31 +9,30 @@ const EditTextScreen = ({ navigation }) => {
 
   const hasUnsavedChanges = Boolean(text);
 
-  React.useEffect(
-    () =>
-      navigation.addListener('beforeRemove', (e) => {
-        const action = e.data.action;
-        if (!hasUnsavedChanges) {
-          return;
-        }
+  React.useEffect(() => {
+    const unsubscribe = navigation.addListener('beforeRemove', (e) => {
+      if (!hasUnsavedChanges) {
+        return;
+      }
 
-        e.preventDefault();
+      e.preventDefault();
 
-        Alert.alert(
-          'Discard changes?',
-          'You have unsaved changes. Are you sure to discard them and leave the screen?',
-          [
-            { text: "Don't leave", style: 'cancel', onPress: () => {} },
-            {
-              text: 'Discard',
-              style: 'destructive',
-              onPress: () => navigation.dispatch(action),
-            },
-          ]
-        );
-      }),
-    [hasUnsavedChanges, navigation]
-  );
+      Alert.alert(
+        'Discard changes?',
+        'You have unsaved changes. Are you sure to discard them and leave the screen?',
+        [
+          { text: "Don't leave", style: 'cancel', onPress: () => {} },
+          {
+            text: 'Discard',
+            style: 'destructive',
+            onPress: () => navigation.dispatch(e.data.action),
+          },
+        ]
+      );
+    });
+
+    return unsubscribe;
+  }, [navigation, hasUnsavedChanges]);
 
   return (
     <View style={styles.content}>

--- a/versioned_docs/version-5.x/preventing-going-back.md
+++ b/versioned_docs/version-5.x/preventing-going-back.md
@@ -53,7 +53,7 @@ function EditText({ navigation }) {
             // This will continue the action that had triggered the removal of the screen
             onPress: () => navigation.dispatch(e.data.action),
           },
-        ],
+        ]
       );
     });
 

--- a/versioned_docs/version-5.x/preventing-going-back.md
+++ b/versioned_docs/version-5.x/preventing-going-back.md
@@ -30,35 +30,36 @@ function EditText({ navigation }) {
   const [text, setText] = React.useState('');
   const hasUnsavedChanges = Boolean(text);
 
-  React.useEffect(
-    () =>
-      navigation.addListener('beforeRemove', (e) => {
-        if (!hasUnsavedChanges) {
-          // If we don't have unsaved changes, then we don't need to do anything
-          return;
-        }
+  React.useEffect(() => {
+    const unsubscribe = navigation.addListener('beforeRemove', (e) => {
+      if (!hasUnsavedChanges) {
+        // If we don't have unsaved changes, then we don't need to do anything
+        return;
+      }
 
-        // Prevent default behavior of leaving the screen
-        e.preventDefault();
+      // Prevent default behavior of leaving the screen
+      e.preventDefault();
 
-        // Prompt the user before leaving the screen
-        Alert.alert(
-          'Discard changes?',
-          'You have unsaved changes. Are you sure to discard them and leave the screen?',
-          [
-            { text: "Don't leave", style: 'cancel', onPress: () => {} },
-            {
-              text: 'Discard',
-              style: 'destructive',
-              // If the user confirmed, then we dispatch the action we blocked earlier
-              // This will continue the action that had triggered the removal of the screen
-              onPress: () => navigation.dispatch(e.data.action),
-            },
-          ]
-        );
-      }),
-    [navigation, hasUnsavedChanges]
-  );
+      // Prompt the user before leaving the screen
+      Alert.alert(
+        'Discard changes?',
+        'You have unsaved changes. Are you sure to discard them and leave the screen?',
+        [
+          { text: "Don't leave", style: 'cancel', onPress: () => {} },
+          {
+            text: 'Discard',
+            style: 'destructive',
+            // If the user confirmed, then we dispatch the action we blocked earlier
+            // This will continue the action that had triggered the removal of the screen
+            onPress: () => navigation.dispatch(e.data.action),
+          },
+        ],
+      );
+    });
+
+    // The unsubscribe function can be returned as the cleanup function in the effect.
+    return unsubscribe;
+  }, [navigation, hasUnsavedChanges]);
 
   return (
     <TextInput

--- a/versioned_docs/version-6.x/preventing-going-back.md
+++ b/versioned_docs/version-6.x/preventing-going-back.md
@@ -17,35 +17,34 @@ function EditText({ navigation }) {
   const [text, setText] = React.useState('');
   const hasUnsavedChanges = Boolean(text);
 
-  React.useEffect(
-    () =>
-      navigation.addListener('beforeRemove', (e) => {
-        if (!hasUnsavedChanges) {
-          // If we don't have unsaved changes, then we don't need to do anything
-          return;
-        }
+  React.useEffect(() => {
+    const unsubscribe = navigation.addListener('beforeRemove', (e) => {
+      if (!hasUnsavedChanges) {
+        // If we don't have unsaved changes, then we don't need to do anything
+        return;
+      }
+      // Prevent default behavior of leaving the screen
+      e.preventDefault();
+      // Prompt the user before leaving the screen
+      Alert.alert(
+        'Discard changes?',
+        'You have unsaved changes. Are you sure to discard them and leave the screen?',
+        [
+          { text: "Don't leave", style: 'cancel', onPress: () => {} },
+          {
+            text: 'Discard',
+            style: 'destructive',
+            // If the user confirmed, then we dispatch the action we blocked earlier
+            // This will continue the action that had triggered the removal of the screen
+            onPress: () => navigation.dispatch(e.data.action),
+          },
+        ],
+      );
+    });
 
-        // Prevent default behavior of leaving the screen
-        e.preventDefault();
-
-        // Prompt the user before leaving the screen
-        Alert.alert(
-          'Discard changes?',
-          'You have unsaved changes. Are you sure to discard them and leave the screen?',
-          [
-            { text: "Don't leave", style: 'cancel', onPress: () => {} },
-            {
-              text: 'Discard',
-              style: 'destructive',
-              // If the user confirmed, then we dispatch the action we blocked earlier
-              // This will continue the action that had triggered the removal of the screen
-              onPress: () => navigation.dispatch(e.data.action),
-            },
-          ]
-        );
-      }),
-    [navigation, hasUnsavedChanges]
-  );
+    // The unsubscribe function can be returned as the cleanup function in the effect.
+    return unsubscribe;
+  }, [navigation, hasUnsavedChanges]);
 
   return (
     <TextInput

--- a/versioned_docs/version-6.x/preventing-going-back.md
+++ b/versioned_docs/version-6.x/preventing-going-back.md
@@ -23,8 +23,10 @@ function EditText({ navigation }) {
         // If we don't have unsaved changes, then we don't need to do anything
         return;
       }
+
       // Prevent default behavior of leaving the screen
       e.preventDefault();
+
       // Prompt the user before leaving the screen
       Alert.alert(
         'Discard changes?',
@@ -38,7 +40,7 @@ function EditText({ navigation }) {
             // This will continue the action that had triggered the removal of the screen
             onPress: () => navigation.dispatch(e.data.action),
           },
-        ],
+        ]
       );
     });
 


### PR DESCRIPTION
I noticed after copying the example that without a cleanup function, multiple instances of this event are sometimes created. I'm relatively new to RN, so let me know if this is incorrect :). 

- [x]  Make sure to add your changes to versioned docs 

