### PR TITLE
fixed link to React Native Express

### DIFF
--- a/versioned_docs/version-6.x/getting-started.md
+++ b/versioned_docs/version-6.x/getting-started.md
@@ -12,7 +12,7 @@ If you're already familiar with JavaScript, React and React Native, then you'll 
 
 Here are some resources to help you out:
 
-1. [React Native Express](http://reactnativeexpress.com/) (Sections 1 to 4)
+1. [React Native Express](https://www.reactnative.express) (Sections 1 to 4)
 2. [Main Concepts of React](https://reactjs.org/docs/hello-world.html)
 3. [React Hooks](https://reactjs.org/docs/hooks-intro.html)
 4. [React Context](https://reactjs.org/docs/context.html) (Advanced)


### PR DESCRIPTION
It seems to have moved from http://reactnativeexpress.com to https://www.reactnative.express

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
