### PR TITLE
docs: Add missing closing tag to extending navigators example

### DIFF
--- a/versioned_docs/version-6.x/custom-navigators.md
+++ b/versioned_docs/version-6.x/custom-navigators.md
@@ -341,7 +341,7 @@ function BottomTabNavigator({
         navigation={navigation}
         descriptors={descriptors}
       />
-    <NavigationContent>
+    </NavigationContent>
   );
 }
 

--- a/versioned_docs/version-7.x/custom-navigators.md
+++ b/versioned_docs/version-7.x/custom-navigators.md
@@ -341,7 +341,7 @@ function BottomTabNavigator({
         navigation={navigation}
         descriptors={descriptors}
       />
-    <NavigationContent>
+    </NavigationContent>
   );
 }
 


### PR DESCRIPTION
### Summary

Correctly close the `NavigationContent` tag so that copying the snippet works out of the box for v6 and v7.

# READ ME PLEASE!

### TL;DR: Make sure to add your changes to versioned docs

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
