### PR TITLE
Update drawer-navigator.md

### DIFF
--- a/versioned_docs/version-6.x/drawer-navigator.md
+++ b/versioned_docs/version-6.x/drawer-navigator.md
@@ -35,7 +35,7 @@ Then, you need to install and configure the libraries that are required by the d
    If you have a bare React Native project, in your project directory, run:
 
    ```bash npm2yarn
-   npm install react-native-gesture-handler react-native-reanimated@2.14.4
+   npm install react-native-gesture-handler react-native-reanimated@^2
    ```
 
    The Drawer Navigator supports both Reanimated 1 and Reanimated 2. If you want to use Reanimated 2, make sure to configure it following the [installation guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation).


### PR DESCRIPTION
Reanimated 3.x release but not work on drawer.  if you can do this  npm install react-native-gesture-handler react-native-reanimated  re-animated install 3.x version. because  you can add  @2.14.4  to this npm.

# READ ME PLEASE

> **TL;DR: Make sure to add your changes to versioned docs**

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
