### PR TITLE
Added steps for install npm dependencies

### DIFF
--- a/versioned_docs/version-6.x/drawer-navigator.md
+++ b/versioned_docs/version-6.x/drawer-navigator.md
@@ -48,7 +48,20 @@ Then, you need to install and configure the libraries that are required by the d
 
    > Note: If you are building for Android or iOS, do not skip this step, or your app may crash in production even if it works fine in development. This is not applicable to other platforms.
 
-3. If you're on a Mac and developing for iOS, you also need to install the pods (via [Cocoapods](https://cocoapods.org/)) to complete the linking.
+3. Optionally, you can also install [`@react-native-masked-view/masked-view`](https://github.com/react-native-masked-view/masked-view). This is needed if you want to use UIKit style animations for the header ([`HeaderStyleInterpolators.forUIKit`](#headerstyleinterpolators)).
+
+   If you have a Expo managed project, in your project directory, run:
+
+   ```bash
+   npx expo install @react-native-masked-view/masked-view
+   ```
+
+   If you have a bare React Native project, in your project directory, run:
+
+   ```bash npm2yarn
+   npm install @react-native-masked-view/masked-view
+
+4. If you're on a Mac and developing for iOS, you also need to install the pods (via [Cocoapods](https://cocoapods.org/)) to complete the linking.
 
 ```bash
 npx pod-install ios


### PR DESCRIPTION
Fix reporting the following error when npm not installing @react-native-masked-view/masked-view：

TypeError: Cannot read property 'getViewManagerConfig' of undefined, js engine: hermes
TypeError: Cannot read property 'SafeAreaProviderCompat' of undefined

# READ ME PLEASE

> **TL;DR: Make sure to add your changes to versioned docs**

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
