### PR TITLE
docs: add headerBackTestID option in Header component

### DIFF
--- a/versioned_docs/version-6.x/elements.md
+++ b/versioned_docs/version-6.x/elements.md
@@ -116,6 +116,10 @@ Color for material ripple (Android >= 5.0 only)
 
 Press opacity for the buttons in header (Android < 5.0, and iOS)
 
+#### `headerBackTestID`
+
+TestID used on the back button. Useful for e2e testing with Detox.
+
 #### `headerTransparent`
 
 Defaults to `false`. If `true`, the header will not have a background unless you explicitly provide it with `headerBackground`. The header will also float over the screen so that it overlaps the content underneath.

--- a/versioned_docs/version-7.x/elements.md
+++ b/versioned_docs/version-7.x/elements.md
@@ -116,6 +116,10 @@ Color for material ripple (Android >= 5.0 only)
 
 Press opacity for the buttons in header (Android < 5.0, and iOS)
 
+#### `headerBackTestID`
+
+TestID used on the back button. Useful for e2e testing with Detox.
+
 #### `headerTransparent`
 
 Defaults to `false`. If `true`, the header will not have a background unless you explicitly provide it with `headerBackground`. The header will also float over the screen so that it overlaps the content underneath.


### PR DESCRIPTION
Add option `headerBackTestID` in Header component in file `elements.md`. Updated both v6 and v7 documentation

# READ ME PLEASE

> **TL;DR: Make sure to add your changes to versioned docs**

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
