### PR TITLE
Update documentation to correct the default value of `labelVisible`

### DIFF
--- a/versioned_docs/version-6.x/elements.md
+++ b/versioned_docs/version-6.x/elements.md
@@ -188,7 +188,7 @@ A component used to show the back button header. It's the default for [`headerLe
 - `tintColor` - Tint color for the header.
 - `label` - Label text for the button. Usually the title of the previous screen. By default, this is only shown on iOS.
 - `truncatedLabel` - Label text to show when there isn't enough space for the full label.
-- `labelVisible` - Whether the label text is visible. Defaults to `true` on iOS and `false` on Android.
+- `labelVisible` - Whether the label text is visible. Defaults to `false` on iOS and Android.
 - `labelStyle` - Style object for the label.
 - `allowFontScaling` - Whether label font should scale to respect Text Size accessibility settings.
 - `onLabelLayout` - Callback to trigger when the size of the label changes.


### PR DESCRIPTION
This is regarding this PR https://github.com/react-navigation/react-navigation/pull/11308. It was recommended to update the documentation, which I never got around to making a PR for.

The documentation currently states that `labelVisible` in `HeaderBackButton` defaults to `true` on iOS while `false` on Android, however that is not correct. On both platforms it defaults to false.

Regardless of what decision you make on that PR, I figure that it may as well be worth updating the 6.x documentation to state that it does not default to true. I'm not sure how prevalent iOS back buttons without a label are, but it may be best to just leave it be until 7.x if you were going to make the change, since there may be those who don't want the label and are just using the default value as of right now.

I've only updated 6.x since I am not sure what your stance will be going forward on the PR and if you would want to implement that into 7.x.

Thanks