### PR TITLE
docs: fix typo in code

### DIFF
--- a/versioned_docs/version-6.x/handling-safe-area.md
+++ b/versioned_docs/version-6.x/handling-safe-area.md
@@ -67,11 +67,11 @@ export default function App() {
         <Stack.Screen name="Home">
           {() => (
             <Tab.Navigator
-              initialRouteName="Analitics"
+              initialRouteName="Analytics"
               tabBar={() => null}
               screenOptions={{ headerShown: false }}
             >
-              <Tab.Screen name="Analitics" component={Demo} />
+              <Tab.Screen name="Analytics" component={Demo} />
               <Tab.Screen name="Profile" component={Demo} />
             </Tab.Navigator>
           )}


### PR DESCRIPTION
The word 'Analitics' is incorrect and it supposed to be 'Analytics'.

# READ ME PLEASE

> **TL;DR: Make sure to add your changes to versioned docs**

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
