### PR TITLE
Provide more robust tab example

### DIFF
--- a/versioned_docs/version-6.x/tab-based-navigation.md
+++ b/versioned_docs/version-6.x/tab-based-navigation.md
@@ -220,8 +220,12 @@ export default function App() {
   return (
     <NavigationContainer>
       <Tab.Navigator screenOptions={{ headerShown: false }}>
-        <Tab.Screen name="Home" component={HomeStackScreen} />
-        <Tab.Screen name="Settings" component={SettingsStackScreen} />
+        <Tab.Screen name="HomeTab" component={HomeStackScreen} options={{
+          tabBarLabel: "Home"
+        }}/>
+        <Tab.Screen name="SettingsTab" component={SettingsStackScreen} options={{
+          tabBarLabel: "Settings"
+        }}/>
       </Tab.Navigator>
     </NavigationContainer>
   );

--- a/versioned_docs/version-7.x/tab-based-navigation.md
+++ b/versioned_docs/version-7.x/tab-based-navigation.md
@@ -220,8 +220,12 @@ export default function App() {
   return (
     <NavigationContainer>
       <Tab.Navigator screenOptions={{ headerShown: false }}>
-        <Tab.Screen name="Home" component={HomeStackScreen} />
-        <Tab.Screen name="Settings" component={SettingsStackScreen} />
+        <Tab.Screen name="HomeTab" component={HomeStackScreen} options={{
+          tabBarLabel: "Home"
+        }}/>
+        <Tab.Screen name="SettingsTab" component={SettingsStackScreen} options={{
+          tabBarLabel: "Settings"
+        }}/>
       </Tab.Navigator>
     </NavigationContainer>
   );


### PR DESCRIPTION
The current version of this example leads to a warning of

```
found screens with the same name nested inside one another
```

This fix removes that error by giving the tabs a different name but allowing the label to still use the same text.

# READ ME PLEASE

> **TL;DR: Make sure to add your changes to versioned docs**

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
