### PR TITLE
Fix typo in stack-navigator and native-stack-navigator for `replace` example

### DIFF
--- a/versioned_docs/version-6.x/native-stack-navigator.md
+++ b/versioned_docs/version-6.x/native-stack-navigator.md
@@ -660,7 +660,7 @@ Replaces the current screen with a new screen in the stack. The method accepts f
 - `params` - _object_ - Screen params to pass to the destination route.
 
 ```js
-navigation.push('Profile', { owner: 'Michaś' });
+navigation.replace('Profile', { owner: 'Michaś' });
 ```
 
 #### `push`

--- a/versioned_docs/version-6.x/stack-navigator.md
+++ b/versioned_docs/version-6.x/stack-navigator.md
@@ -459,7 +459,7 @@ Replaces the current screen with a new screen in the stack. The method accepts f
 - `params` - _object_ - Screen params to pass to the destination route.
 
 ```js
-navigation.push('Profile', { owner: 'Michaś' });
+navigation.replace('Profile', { owner: 'Michaś' });
 ```
 
 #### `push`

--- a/versioned_docs/version-7.x/native-stack-navigator.md
+++ b/versioned_docs/version-7.x/native-stack-navigator.md
@@ -658,7 +658,7 @@ Replaces the current screen with a new screen in the stack. The method accepts f
 - `params` - _object_ - Screen params to pass to the destination route.
 
 ```js
-navigation.push('Profile', { owner: 'Michaś' });
+navigation.replace('Profile', { owner: 'Michaś' });
 ```
 
 #### `push`

--- a/versioned_docs/version-7.x/stack-navigator.md
+++ b/versioned_docs/version-7.x/stack-navigator.md
@@ -459,7 +459,7 @@ Replaces the current screen with a new screen in the stack. The method accepts f
 - `params` - _object_ - Screen params to pass to the destination route.
 
 ```js
-navigation.push('Profile', { owner: 'Michaś' });
+navigation.replace('Profile', { owner: 'Michaś' });
 ```
 
 #### `push`


### PR DESCRIPTION
The code examples for `replace` in both `stack-navigator` and `native-stack-navigator` were using the `push` method instead of `replace`.