### PR TITLE
docs: mention the header buttons lib

### DIFF
--- a/versioned_docs/version-6.x/header-buttons.md
+++ b/versioned_docs/version-6.x/header-buttons.md
@@ -37,6 +37,8 @@ function StackScreen() {
 
 When we define our button this way, the `this` variable in `options` is _not_ the `HomeScreen` instance, so you can't call `setState` or any instance methods on it. This is pretty important because it's extremely common to want the buttons in your header to interact with the screen that the header belongs to. So, we will look how to do this next.
 
+> 💡 Please note that a community-developed library for rendering buttons in the header with the correct styling is available: [react-navigation-header-buttons](https://github.com/vonovak/react-navigation-header-buttons).
+
 ## Header interaction with its screen component
 
 In some cases, components in the header need to interact with the screen component. For this use case, we need to use `navigation.setOptions` to update our options. By using `navigation.setOptions` inside the screen component, we get access to screen's props, state, context etc.


### PR DESCRIPTION
This was documented for previous versions of react-navigation. I recently revamped the package so that it can be used in v6 (and probably in v7 as well).

see eg. https://reactnavigation.org/docs/5.x/header-buttons

so I felt like it might be useful to people, thank you