### PR TITLE
Update hiding-tabbar-in-screens with style option.md

### DIFF
--- a/versioned_docs/version-6.x/hiding-tabbar-in-screens.md
+++ b/versioned_docs/version-6.x/hiding-tabbar-in-screens.md
@@ -59,3 +59,55 @@ function App() {
 ```
 
 After re-organizing the navigation structure, now if we navigate to the `Profile` or `Settings` screens, the tab bar won't be visible over the screen anymore.
+
+### Alternative Options - Hiding the bar via stylea
+
+Use cases
+1. Screens must be nested within the tabs instead of in reverse.
+2. There are multiple nested tab implementations such as a backgroundTab that deeply nested another tab.
+
+Code
+
+```js
+import { StyleSheet } from 'react-native'
+
+const styles = StyleSheet.create({
+  hiddenTabBar: {
+    width: 0,
+    height: 0,
+    position: 'absolute',
+    zIndex: -999, // prevents tab from clipping into view (android+ios)
+    elevation: -999, // prevents tab from clipping into view (android)
+  },
+})
+
+function HomeStack() {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen name="Home" component={Home} />
+      <Stack.Screen name="Profile" component={Profile} />
+      <Stack.Screen name="Settings" component={Settings} />
+    </Stack.Navigator>
+  );
+}
+
+function App() {
+  /** 
+   * @description this could be global state context
+   */
+  const globalStore = { bottomTabVisibility: false }
+
+  const screenOptions = useMemo(() => ({ tabBarStyle: globalStore?.bottomTabVisibility
+                    ? undefined
+                    : styles.hiddenTabBar}),[globalStore?.bottomTabVisibility])
+  return (
+    <NavigationContainer>
+      <Stack.Navigator screenOptions={screenOptions}>
+        <Stack.Screen name="Home" component={HomeTabs} />
+        <Stack.Screen name="Profile" component={Profile} />
+        <Stack.Screen name="Settings" component={Settings} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+```


### PR DESCRIPTION
- adds a second option using react-native styles to hide the bottom bar.
- The current example (moving the stack above the tabs) shows ideal use cases while the second option works when those ideal use cases are not an option.

# READ ME PLEASE

> **TL;DR: Make sure to add your changes to versioned docs**

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
