### PR TITLE
Example consistency fix

### DIFF
--- a/versioned_docs/version-5.x/configuring-links.md
+++ b/versioned_docs/version-5.x/configuring-links.md
@@ -622,7 +622,7 @@ const linking = {
       Chat: 'feed/:sort',
     },
   },
-  getStateFromPath: (path, options) => {
+  getStateFromPath(path, options) {
     // Return a state object here
     // You can also reuse the default logic by importing `getStateFromPath` from `@react-navigation/native`
   },

--- a/versioned_docs/version-6.x/configuring-links.md
+++ b/versioned_docs/version-6.x/configuring-links.md
@@ -660,7 +660,7 @@ const linking = {
       Chat: 'feed/:sort',
     },
   },
-  getStateFromPath: (path, options) => {
+  getStateFromPath(path, options) {
     // Return a state object here
     // You can also reuse the default logic by importing `getStateFromPath` from `@react-navigation/native`
   },

--- a/versioned_docs/version-7.x/configuring-links.md
+++ b/versioned_docs/version-7.x/configuring-links.md
@@ -660,7 +660,7 @@ const linking = {
       Chat: 'feed/:sort',
     },
   },
-  getStateFromPath: (path, options) => {
+  getStateFromPath(path, options) {
     // Return a state object here
     // You can also reuse the default logic by importing `getStateFromPath` from `@react-navigation/native`
   },


### PR DESCRIPTION
Thank's for taking the time to review. This change matches the example code in other sections like v5 linkto, and the example of getPathFromState right underneath the modified code. As an infrequent JS coder the inconsistency caused me some confusion. Hopefully this change will help others in my position.