### PR TITLE
Update deep-linking.md - Fix Declare Association between website and …

### DIFF
--- a/versioned_docs/version-6.x/deep-linking.md
+++ b/versioned_docs/version-6.x/deep-linking.md
@@ -185,7 +185,7 @@ After adding them, it should look like this:
 </activity>
 ```
 
-Then, you need to [declare the association](https://developer.android.com/training/app-links/verify-site-associations#web-assoc) between your website and your intent filters by hosting a Digital Asset Links JSON file.
+Then, you need to [declare the association](https://developer.android.com/training/app-links/verify-android-applinks#web-assoc) between your website and your intent filters by hosting a Digital Asset Links JSON file.
 
 ## Testing deep links
 


### PR DESCRIPTION
…intent-filters external documentation url

The current link redirects to https://support.google.com/android/search?q=open+by+default#web-assoc which does not provide the intended document. I changed it to the actual url which is 'https://developer.android.com/training/app-links/verify-android-applinks#web-assoc'

# READ ME PLEASE

> **TL;DR: Make sure to add your changes to versioned docs**

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
