### PR TITLE
Update configuring-links.md

### DIFF
--- a/versioned_docs/version-5.x/configuring-links.md
+++ b/versioned_docs/version-5.x/configuring-links.md
@@ -442,6 +442,22 @@ const state = {
 };
 ```
 
+The `initialRouteName` property is also valid as a top-level key, this is useful if you want to add a base screen to a top-level route
+
+```js
+const config = {
+  initialRouteName: 'Feed',
+  screens: {
+    Home: {
+      screens: {
+        Profile: 'users/:id',
+        Settings: 'settings',
+      },
+    },
+  },
+};
+```
+
 It's not possible to pass params to the initial screen through the URL. So make sure that your initial route doesn't need any params or specify `initialParams` to pass required params.
 
 In this case, any params in the URL are only passed to the `Profile` screen which matches the path pattern `users/:id`, and the `Feed` screen doesn't receive any params. If you want to have the same params in the `Feed` screen, you can specify a [custom `getStateFromPath` function](navigation-container.md#linkinggetstatefrompath) and copy those params.

--- a/versioned_docs/version-6.x/configuring-links.md
+++ b/versioned_docs/version-6.x/configuring-links.md
@@ -479,6 +479,21 @@ const state = {
   ],
 };
 ```
+The `initialRouteName` property is also valid as a top-level key, this is useful if you want to add a base screen to a top-level route
+
+```js
+const config = {
+  initialRouteName: 'Feed',
+  screens: {
+    Home: {
+      screens: {
+        Profile: 'users/:id',
+        Settings: 'settings',
+      },
+    },
+  },
+};
+```
 
 It's not possible to pass params to the initial screen through the URL. So make sure that your initial route doesn't need any params or specify `initialParams` to pass required params.
 

--- a/versioned_docs/version-6.x/configuring-links.md
+++ b/versioned_docs/version-6.x/configuring-links.md
@@ -479,6 +479,7 @@ const state = {
   ],
 };
 ```
+
 The `initialRouteName` property is also valid as a top-level key, this is useful if you want to add a base screen to a top-level route
 
 ```js

--- a/versioned_docs/version-7.x/configuring-links.md
+++ b/versioned_docs/version-7.x/configuring-links.md
@@ -480,6 +480,22 @@ const state = {
 };
 ```
 
+The `initialRouteName` property is also valid as a top-level key, this is useful if you want to add a base screen to a top-level route
+
+```js
+const config = {
+  initialRouteName: 'Feed',
+  screens: {
+    Home: {
+      screens: {
+        Profile: 'users/:id',
+        Settings: 'settings',
+      },
+    },
+  },
+};
+```
+
 It's not possible to pass params to the initial screen through the URL. So make sure that your initial route doesn't need any params or specify `initialParams` to pass required params.
 
 In this case, any params in the URL are only passed to the `Profile` screen which matches the path pattern `users/:id`, and the `Feed` screen doesn't receive any params. If you want to have the same params in the `Feed` screen, you can specify a [custom `getStateFromPath` function](navigation-container.md#linkinggetstatefrompath) and copy those params.


### PR DESCRIPTION
# Overview

I have a main navigator with a bunch of screens, I wanted a deep link to one of those screens to go back to the initial route and I couldn't get it to work, after diving into the source code I found that a top-level `initialRouteName` can be passed and that solved my problem, the docs are a bit ambiguous so this PR hopefully will save the next person a few hours of debugging 

Thank you so much for making and maintaining react-navigation, it's amazing and delightful working with it!

## TODO
- [x] update all the different docs version