### PR TITLE
chore: add kotlin version of code

### DIFF
--- a/versioned_docs/version-6.x/getting-started.md
+++ b/versioned_docs/version-6.x/getting-started.md
@@ -70,20 +70,35 @@ npx pod-install ios
 ```
 
 `react-native-screens` package requires one additional configuration step to properly
-work on Android devices. Edit `MainActivity.java` file which is located in `android/app/src/main/java/<your package name>/MainActivity.java`.
+work on Android devices. Edit `MainActivity.kt` file which is located in `android/app/src/main/java/<your package name>/MainActivity.kt`.
 
 Add the highlighted code to the body of `MainActivity` class:
 
-```java {3-6}
-public class MainActivity extends ReactActivity {
-  // ...
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(null);
-  }
-  // ...
-}
-```
+<Tabs>
+  <TabItem value='kotlin' label='Kotlin' default>
+    ```kotlin {3-5}
+    class MainActivity: ReactActivity() {
+      // ...
+      override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(null)
+      }
+      // ...
+    }
+    ```
+  </TabItem>
+  <TabItem value='java' label='Java'>
+    ```java {3-6}
+    public class MainActivity extends ReactActivity {
+      // ...
+      @Override
+      protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(null);
+      }
+      // ...
+    }
+    ```
+  </TabItem>
+</Tabs>
 
 and make sure to add the following import statement at the top of this file below your package statement:
 

--- a/versioned_docs/version-6.x/getting-started.md
+++ b/versioned_docs/version-6.x/getting-started.md
@@ -70,7 +70,7 @@ npx pod-install ios
 ```
 
 `react-native-screens` package requires one additional configuration step to properly
-work on Android devices. Edit `MainActivity.kt` file which is located in `android/app/src/main/java/<your package name>/MainActivity.kt`.
+work on Android devices. Edit `MainActivity.kt` or `MainActivity.java` file which is located under `android/app/src/main/java/<your package name>/`.
 
 Add the highlighted code to the body of `MainActivity` class:
 

--- a/versioned_docs/version-7.x/getting-started.md
+++ b/versioned_docs/version-7.x/getting-started.md
@@ -70,20 +70,35 @@ npx pod-install ios
 ```
 
 `react-native-screens` package requires one additional configuration step to properly
-work on Android devices. Edit `MainActivity.java` file which is located in `android/app/src/main/java/<your package name>/MainActivity.java`.
+work on Android devices. Edit `MainActivity.kt` file which is located in `android/app/src/main/java/<your package name>/MainActivity.kt`.
 
 Add the highlighted code to the body of `MainActivity` class:
 
-```java {3-6}
-public class MainActivity extends ReactActivity {
-  // ...
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(null);
-  }
-  // ...
-}
-```
+<Tabs>
+  <TabItem value='kotlin' label='Kotlin' default>
+    ```kotlin {3-5}
+    class MainActivity: ReactActivity() {
+      // ...
+      override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(null)
+      }
+      // ...
+    }
+    ```
+  </TabItem>
+  <TabItem value='java' label='Java'>
+    ```java {3-6}
+    public class MainActivity extends ReactActivity {
+      // ...
+      @Override
+      protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(null);
+      }
+      // ...
+    }
+    ```
+  </TabItem>
+</Tabs>
 
 and make sure to add the following import statement at the top of this file below your package statement:
 

--- a/versioned_docs/version-7.x/getting-started.md
+++ b/versioned_docs/version-7.x/getting-started.md
@@ -70,7 +70,7 @@ npx pod-install ios
 ```
 
 `react-native-screens` package requires one additional configuration step to properly
-work on Android devices. Edit `MainActivity.kt` file which is located in `android/app/src/main/java/<your package name>/MainActivity.kt`.
+work on Android devices. Edit `MainActivity.kt` or `MainActivity.java` file which is located under `android/app/src/main/java/<your package name>/`.
 
 Add the highlighted code to the body of `MainActivity` class:
 


### PR DESCRIPTION
Kotlin is now used in the template starting at 0.73. This PR adds Kotlin examples together with Java.

Currently, Java is opened by default while Kotlin is collapsed, not sure if I should swap, just let me know.

Source: https://github.com/software-mansion/react-native-screens#android

<img width="993" alt="Screenshot 2023-12-07 at 18 44 16" src="https://github.com/react-navigation/react-navigation.github.io/assets/36528176/102bd81d-b2f7-4255-8dda-c667ac4388b6">

<img width="1004" alt="Screenshot 2023-12-07 at 18 44 24" src="https://github.com/react-navigation/react-navigation.github.io/assets/36528176/ff6a6444-8270-49bd-ac87-2381621f739d">

