### PR TITLE
fixes the re-render warning for using useIsFocused

### DIFF
--- a/versioned_docs/version-6.x/use-is-focused.md
+++ b/versioned_docs/version-6.x/use-is-focused.md
@@ -20,7 +20,7 @@ function Profile() {
 }
 ```
 
-Note that using this hook in a component triggers a re-render on that component when the focus is changed for the screen that contains the component. This might cause lags during the animation if your component is heavy. You might want to extract the expensive parts to separate components and use [`React.memo`](https://reactjs.org/docs/react-api.html#reactmemo) or [`React.PureComponent`](https://reactjs.org/docs/react-api.html#reactpurecomponent) to minimize re-renders for them.
+Note that using this hook triggers a re-render for the component when the screen it's in changes focus. This might cause lags during the animation if your component is heavy. You might want to extract the expensive parts to separate components and use [`React.memo`](https://reactjs.org/docs/react-api.html#reactmemo) or [`React.PureComponent`](https://reactjs.org/docs/react-api.html#reactpurecomponent) to minimize re-renders for them.
 
 ## Using with class component
 

--- a/versioned_docs/version-6.x/use-is-focused.md
+++ b/versioned_docs/version-6.x/use-is-focused.md
@@ -20,7 +20,7 @@ function Profile() {
 }
 ```
 
-Note that using this hook triggers a re-render for the screen when it changes focus. This might cause lags during the animation if your screen is heavy. You might want to extract the expensive parts to separate components and use [`React.memo`](https://reactjs.org/docs/react-api.html#reactmemo) or [`React.PureComponent`](https://reactjs.org/docs/react-api.html#reactpurecomponent) to minimize re-renders for them.
+Note that using this hook in a component triggers a re-render on that component when the focus is changed for the screen that contains the component. This might cause lags during the animation if your component is heavy. You might want to extract the expensive parts to separate components and use [`React.memo`](https://reactjs.org/docs/react-api.html#reactmemo) or [`React.PureComponent`](https://reactjs.org/docs/react-api.html#reactpurecomponent) to minimize re-renders for them.
 
 ## Using with class component
 

--- a/versioned_docs/version-7.x/use-is-focused.md
+++ b/versioned_docs/version-7.x/use-is-focused.md
@@ -20,7 +20,7 @@ function Profile() {
 }
 ```
 
-Note that using this hook in a component triggers a re-render on that component when the focus is changed for the screen that contains the component. This might cause lags during the animation if your component is heavy. You might want to extract the expensive parts to separate components and use [`React.memo`](https://reactjs.org/docs/react-api.html#reactmemo) or [`React.PureComponent`](https://reactjs.org/docs/react-api.html#reactpurecomponent) to minimize re-renders for them.
+Note that using this hook triggers a re-render for the component when the screen it's in changes focus. This might cause lags during the animation if your component is heavy. You might want to extract the expensive parts to separate components and use [`React.memo`](https://reactjs.org/docs/react-api.html#reactmemo) or [`React.PureComponent`](https://reactjs.org/docs/react-api.html#reactpurecomponent) to minimize re-renders for them.
 
 ## Using with class component
 

--- a/versioned_docs/version-7.x/use-is-focused.md
+++ b/versioned_docs/version-7.x/use-is-focused.md
@@ -20,7 +20,7 @@ function Profile() {
 }
 ```
 
-Note that using the `useIsFocused` in a component triggers a re-render on that component when the focus is changed for the screen that contains the component. This might cause lags during the animation if your component is heavy. You might want to extract the expensive parts to separate components and use [`React.memo`](https://reactjs.org/docs/react-api.html#reactmemo) or [`React.PureComponent`](https://reactjs.org/docs/react-api.html#reactpurecomponent) to minimize re-renders for them.
+Note that using this hook in a component triggers a re-render on that component when the focus is changed for the screen that contains the component. This might cause lags during the animation if your component is heavy. You might want to extract the expensive parts to separate components and use [`React.memo`](https://reactjs.org/docs/react-api.html#reactmemo) or [`React.PureComponent`](https://reactjs.org/docs/react-api.html#reactpurecomponent) to minimize re-renders for them.
 
 ## Using with class component
 

--- a/versioned_docs/version-7.x/use-is-focused.md
+++ b/versioned_docs/version-7.x/use-is-focused.md
@@ -20,7 +20,7 @@ function Profile() {
 }
 ```
 
-Note that using this hook triggers a re-render for the screen when it changes focus. This might cause lags during the animation if your screen is heavy. You might want to extract the expensive parts to separate components and use [`React.memo`](https://reactjs.org/docs/react-api.html#reactmemo) or [`React.PureComponent`](https://reactjs.org/docs/react-api.html#reactpurecomponent) to minimize re-renders for them.
+Note that using the `useIsFocused` in a component triggers a re-render on that component when the focus is changed for the screen that contains the component. This might cause lags during the animation if your component is heavy. You might want to extract the expensive parts to separate components and use [`React.memo`](https://reactjs.org/docs/react-api.html#reactmemo) or [`React.PureComponent`](https://reactjs.org/docs/react-api.html#reactpurecomponent) to minimize re-renders for them.
 
 ## Using with class component
 


### PR DESCRIPTION
It re-renders the direct component that contains this hook, but it was mentioned that it re-renders the screen.

# READ ME PLEASE

> **TL;DR: Make sure to add your changes to versioned docs**

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
