### PR TITLE
Migrate 'State persistance' examples to static API

### DIFF
--- a/versioned_docs/version-7.x/state-persistence.md
+++ b/versioned_docs/version-7.x/state-persistence.md
@@ -82,7 +82,7 @@ const SettingsStackScreen = createNativeStackNavigator({
 const PERSISTENCE_KEY = 'NAVIGATION_STATE_V1';
 
 export default function App() {
-  const [isReady, setIsReady] = React.useState(false);
+  const [isReady, setIsReady] = React.useState(Platform.OS === 'web'); // Don't persist state on web since it's based on URL
   const [initialState, setInitialState] = React.useState();
 
   React.useEffect(() => {
@@ -168,9 +168,7 @@ function A() {
 function B({ navigation }) {
   return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <Button title="" onPress={() => navigation.navigate('C')}>
-        Go to C
-      </Button>
+      <Button onPress={() => navigation.navigate('C')}>Go to C</Button>
     </View>
   );
 }
@@ -210,7 +208,7 @@ function SettingsStackScreen() {
 const PERSISTENCE_KEY = 'NAVIGATION_STATE_V1';
 
 export default function App() {
-  const [isReady, setIsReady] = React.useState(false);
+  const [isReady, setIsReady] = React.useState(Platform.OS === 'web'); // Don't persist state on web since it's based on URL
   const [initialState, setInitialState] = React.useState();
 
   React.useEffect(() => {

--- a/versioned_docs/version-7.x/state-persistence.md
+++ b/versioned_docs/version-7.x/state-persistence.md
@@ -21,16 +21,17 @@ To be able to persist the [navigation state](navigation-state.md), we can use th
 <Tabs groupId="config" queryString="config">
 <TabItem value="static" label="Static" default>
 
-```js name="Persisting the navigation state" snack version=7
+```js name="Persisting the navigation state" snack version=7 dependencies=@react-native-async-storage/async-storage
 import * as React from 'react';
 // codeblock-focus-start
-import { Platform, View, Button, Linking } from 'react-native';
+import { Platform, View, Linking } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   useNavigation,
   createStaticNavigation,
 } from '@react-navigation/native';
 // codeblock-focus-end
+import { Button } from '@react-navigation/elements';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
@@ -43,7 +44,7 @@ function B() {
 
   return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <Button title="Go to C" onPress={() => navigation.navigate('C')} />
+      <Button onPress={() => navigation.navigate('C')}>Go to C</Button>
     </View>
   );
 }
@@ -53,7 +54,7 @@ function C() {
 
   return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <Button title="Go to D" onPress={() => navigation.navigate('D')} />
+      <Button onPress={() => navigation.navigate('D')}>Go to D</Button>
     </View>
   );
 }
@@ -145,13 +146,14 @@ export default function App() {
 </TabItem>
 <TabItem value="dynamic" label="Dynamic" default>
 
-```js name="Persisting the navigation state" snack version=7
+```js name="Persisting the navigation state" snack version=7 dependencies=@react-native-async-storage/async-storage
 import * as React from 'react';
 // codeblock-focus-start
-import { Platform, View, Button, Linking } from 'react-native';
+import { Platform, View, Linking } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { NavigationContainer } from '@react-navigation/native';
 // codeblock-focus-end
+import { Button } from '@react-navigation/elements';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
@@ -166,7 +168,9 @@ function A() {
 function B({ navigation }) {
   return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <Button title="Go to C" onPress={() => navigation.navigate('C')} />
+      <Button title="" onPress={() => navigation.navigate('C')}>
+        Go to C
+      </Button>
     </View>
   );
 }
@@ -174,7 +178,7 @@ function B({ navigation }) {
 function C({ navigation }) {
   return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <Button title="Go to D" onPress={() => navigation.navigate('D')} />
+      <Button onPress={() => navigation.navigate('D')}>Go to D</Button>
     </View>
   );
 }

--- a/versioned_docs/version-7.x/state-persistence.md
+++ b/versioned_docs/version-7.x/state-persistence.md
@@ -18,8 +18,6 @@ To be able to persist the [navigation state](navigation-state.md), we can use th
 - `onStateChange` - This prop notifies us of any state changes. We can persist the state in this callback.
 - `initialState` - This prop allows us to pass an initial state to use for [navigation state](navigation-state.md). We can pass the restored state in this prop.
 
-<samp id="state-persistance" />
-
 <Tabs groupId="config" queryString="config">
 <TabItem value="static" label="Static" default>
 


### PR DESCRIPTION
[AsyncStorage](https://reactnative.dev/docs/asyncstorage) removed from core React-Native, replaced by [react-native-async-storage](https://github.com/react-native-async-storage/async-storage)