### PR TITLE
Migrate 'Hooks' examples to static API in v7

### DIFF
--- a/versioned_docs/version-7.x/use-focus-effect.md
+++ b/versioned_docs/version-7.x/use-focus-effect.md
@@ -17,20 +17,16 @@ To make this easier, the library exports a `useFocusEffect` hook:
 ```js name="useFocusEffect hook" snack version=7
 import * as React from 'react';
 import { View } from 'react-native';
-import {
-  createStaticNavigation,
-  useFocusEffect,
-} from '@react-navigation/native';
+import { createStaticNavigation } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-
 // codeblock-focus-start
+import { useFocusEffect } from '@react-navigation/native';
+
 function ProfileScreen() {
   useFocusEffect(
     React.useCallback(() => {
-      alert('Screen was focused');
       // Do something when the screen is focused
       return () => {
-        alert('Screen was unfocused');
         // Do something when the screen is unfocused
         // Useful for cleanup functions
       };
@@ -65,17 +61,17 @@ export default function App() {
 ```js name="useFocusEffect hook" snack version=7
 import * as React from 'react';
 import { View } from 'react-native';
-import { NavigationContainer, useFocusEffect } from '@react-navigation/native';
+import { NavigationContainer } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 
 // codeblock-focus-start
+import { useFocusEffect } from '@react-navigation/native';
+
 function ProfileScreen() {
   useFocusEffect(
     React.useCallback(() => {
-      alert('Screen was focused');
       // Do something when the screen is focused
       return () => {
-        alert('Screen was unfocused');
         // Do something when the screen is unfocused
         // Useful for cleanup functions
       };

--- a/versioned_docs/version-7.x/use-focus-effect.md
+++ b/versioned_docs/version-7.x/use-focus-effect.md
@@ -60,7 +60,7 @@ export default function App() {
 ```
 
 </TabItem>
-<TabItem value="dynamic" label="Dynamic" default>
+<TabItem value="dynamic" label="Dynamic">
 
 ```js name="useFocusEffect hook" snack version=7
 import * as React from 'react';

--- a/versioned_docs/version-7.x/use-focus-effect.md
+++ b/versioned_docs/version-7.x/use-focus-effect.md
@@ -4,29 +4,108 @@ title: useFocusEffect
 sidebar_label: useFocusEffect
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 Sometimes we want to run side-effects when a screen is focused. A side effect may involve things like adding an event listener, fetching data, updating document title, etc. While this can be achieved using `focus` and `blur` events, it's not very ergonomic.
 
 To make this easier, the library exports a `useFocusEffect` hook:
 
-<samp id="simple-focus-effect" />
+<Tabs groupId="config" queryString="config">
+<TabItem value="static" label="Static" default>
 
-```js
-import { useFocusEffect } from '@react-navigation/native';
+```js name="useFocusEffect hook" snack version=7
+import * as React from 'react';
+import { View } from 'react-native';
+import {
+  createStaticNavigation,
+  useFocusEffect,
+} from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 
-function Profile({ userId }) {
-  const [user, setUser] = React.useState(null);
-
+// codeblock-focus-start
+function ProfileScreen() {
   useFocusEffect(
     React.useCallback(() => {
-      const unsubscribe = API.subscribe(userId, user => setUser(user));
-
-      return () => unsubscribe();
-    }, [userId])
+      alert('Screen was focused');
+      // Do something when the screen is focused
+      return () => {
+        alert('Screen was unfocused');
+        // Do something when the screen is unfocused
+        // Useful for cleanup functions
+      };
+    }, [])
   );
 
-  return <ProfileContent user={user} />;
+  return <View />;
+}
+// codeblock-focus-end
+
+function HomeScreen() {
+  return <View />;
+}
+
+const Tab = createBottomTabNavigator({
+  screens: {
+    Home: HomeScreen,
+    Profile: ProfileScreen,
+  },
+});
+
+const Navigation = createStaticNavigation(Tab);
+
+export default function App() {
+  return <Navigation />;
 }
 ```
+
+</TabItem>
+<TabItem value="dynamic" label="Dynamic" default>
+
+```js name="useFocusEffect hook" snack version=7
+import * as React from 'react';
+import { View } from 'react-native';
+import { NavigationContainer, useFocusEffect } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+
+// codeblock-focus-start
+function ProfileScreen() {
+  useFocusEffect(
+    React.useCallback(() => {
+      alert('Screen was focused');
+      // Do something when the screen is focused
+      return () => {
+        alert('Screen was unfocused');
+        // Do something when the screen is unfocused
+        // Useful for cleanup functions
+      };
+    }, [])
+  );
+
+  return <View />;
+}
+// codeblock-focus-end
+
+function HomeScreen() {
+  return <View />;
+}
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Tab.Navigator>
+        <Tab.Screen name="Home" component={HomeScreen} />
+        <Tab.Screen name="Profile" component={ProfileScreen} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}
+```
+
+</TabItem>
+</Tabs>
 
 :::warning
 
@@ -107,7 +186,7 @@ useFocusEffect(
   React.useCallback(() => {
     return () => {
       // Do something that should run on blur
-    }
+    };
   }, [])
 );
 ```
@@ -116,7 +195,7 @@ The cleanup function runs whenever the effect needs to cleanup, i.e. on `blur`, 
 
 ```js
 React.useEffect(() => {
-    const unsubscribe = navigation.addListener('blur', () => {
+  const unsubscribe = navigation.addListener('blur', () => {
     // Do something when the screen blurs
   });
 
@@ -146,7 +225,7 @@ function FetchUserData({ userId, onUpdate }) {
 // ...
 
 class Profile extends React.Component {
-  _handleUpdate = user => {
+  _handleUpdate = (user) => {
     // Do something with user object
   };
 

--- a/versioned_docs/version-7.x/use-is-focused.md
+++ b/versioned_docs/version-7.x/use-is-focused.md
@@ -15,9 +15,10 @@ We might want to render different content based on the current focus state of th
 ```js name="useIsFocused hook" snack version=7
 import * as React from 'react';
 import { View, Text } from 'react-native';
+import { createStaticNavigation } from '@react-navigation/native';
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 // codeblock-focus-start
-import { createStaticNavigation, useIsFocused } from '@react-navigation/native';
+import { useIsFocused } from '@react-navigation/native';
 
 function ProfileScreen() {
   // This hook returns `true` if the screen is focused, `false` otherwise
@@ -56,9 +57,10 @@ export default function App() {
 ```js name="useIsFocused hook" snack version=7
 import * as React from 'react';
 import { View, Text } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 // codeblock-focus-start
-import { NavigationContainer, useIsFocused } from '@react-navigation/native';
+import { useIsFocused } from '@react-navigation/native';
 
 function ProfileScreen() {
   // This hook returns `true` if the screen is focused, `false` otherwise

--- a/versioned_docs/version-7.x/use-is-focused.md
+++ b/versioned_docs/version-7.x/use-is-focused.md
@@ -4,21 +4,95 @@ title: useIsFocused
 sidebar_label: useIsFocused
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 We might want to render different content based on the current focus state of the screen. The library exports a `useIsFocused` hook to make this easier:
 
-<samp id="use-is-focused" />
+<Tabs groupId="config" queryString="config">
+<TabItem value="static" label="Static" default>
 
-```js
-import { useIsFocused } from '@react-navigation/native';
+```js name="useIsFocused hook" snack version=7
+import * as React from 'react';
+import { View, Text } from 'react-native';
+import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
+// codeblock-focus-start
+import { createStaticNavigation, useIsFocused } from '@react-navigation/native';
 
-// ...
-
-function Profile() {
+function ProfileScreen() {
+  // This hook returns `true` if the screen is focused, `false` otherwise
+  // highlight-next-line
   const isFocused = useIsFocused();
 
-  return <Text>{isFocused ? 'focused' : 'unfocused'}</Text>;
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>{isFocused ? 'focused' : 'unfocused'}</Text>
+    </View>
+  );
+}
+// codeblock-focus-end
+
+function HomeScreen() {
+  return <View />;
+}
+
+const Tab = createMaterialTopTabNavigator({
+  screens: {
+    Home: HomeScreen,
+    Profile: ProfileScreen,
+  },
+});
+
+const Navigation = createStaticNavigation(Tab);
+
+export default function App() {
+  return <Navigation />;
 }
 ```
+
+</TabItem>
+<TabItem value="dynamic" label="Dynamic" default>
+
+```js name="useIsFocused hook" snack version=7
+import * as React from 'react';
+import { View, Text } from 'react-native';
+import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
+// codeblock-focus-start
+import { NavigationContainer, useIsFocused } from '@react-navigation/native';
+
+function ProfileScreen() {
+  // This hook returns `true` if the screen is focused, `false` otherwise
+  // highlight-next-line
+  const isFocused = useIsFocused();
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>{isFocused ? 'focused' : 'unfocused'}</Text>
+    </View>
+  );
+}
+// codeblock-focus-end
+
+function HomeScreen() {
+  return <View />;
+}
+
+const Tab = createMaterialTopTabNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Tab.Navigator>
+        <Tab.Screen name="Home" component={HomeScreen} />
+        <Tab.Screen name="Profile" component={ProfileScreen} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}
+```
+
+</TabItem>
+</Tabs>
 
 Note that using this hook triggers a re-render for the component when the screen it's in changes focus. This might cause lags during the animation if your component is heavy. You might want to extract the expensive parts to separate components and use [`React.memo`](https://reactjs.org/docs/react-api.html#reactmemo) or [`React.PureComponent`](https://reactjs.org/docs/react-api.html#reactpurecomponent) to minimize re-renders for them.
 
@@ -35,7 +109,7 @@ class Profile extends React.Component {
 }
 
 // Wrap and export
-export default function(props) {
+export default function (props) {
   const isFocused = useIsFocused();
 
   return <Profile {...props} isFocused={isFocused} />;

--- a/versioned_docs/version-7.x/use-is-focused.md
+++ b/versioned_docs/version-7.x/use-is-focused.md
@@ -51,7 +51,7 @@ export default function App() {
 ```
 
 </TabItem>
-<TabItem value="dynamic" label="Dynamic" default>
+<TabItem value="dynamic" label="Dynamic">
 
 ```js name="useIsFocused hook" snack version=7
 import * as React from 'react';

--- a/versioned_docs/version-7.x/use-navigation-state.md
+++ b/versioned_docs/version-7.x/use-navigation-state.md
@@ -142,7 +142,7 @@ export default function App() {
 ```
 
 </TabItem>
-<TabItem value="dynamic" label="Dynamic" default>
+<TabItem value="dynamic" label="Dynamic">
 
 ```js name="useNavigationState hook" snack version=7
 import * as React from 'react';

--- a/versioned_docs/version-7.x/use-navigation-state.md
+++ b/versioned_docs/version-7.x/use-navigation-state.md
@@ -151,6 +151,7 @@ import { View, Text } from 'react-native';
 import {
   NavigationContainer,
   useRoute,
+  useNavigation,
   useNavigationState,
 } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
@@ -174,7 +175,8 @@ function usePreviousRouteName() {
 }
 // codeblock-focus-end
 
-function HomeScreen({ navigation }) {
+function HomeScreen() {
+  const navigation = useNavigation();
   const isFirstRoute = useIsFirstRouteInParent();
   const previousRouteName = usePreviousRouteName();
   return (
@@ -189,7 +191,8 @@ function HomeScreen({ navigation }) {
   );
 }
 
-function ProfileScreen({ navigation }) {
+function ProfileScreen() {
+  const navigation = useNavigation();
   const isFirstRoute = useIsFirstRouteInParent();
   const previousRouteName = usePreviousRouteName();
   return (
@@ -204,7 +207,8 @@ function ProfileScreen({ navigation }) {
   );
 }
 
-function SettingsScreen({ navigation }) {
+function SettingsScreen() {
+  const navigation = useNavigation();
   const isFirstRoute = useIsFirstRouteInParent();
   const previousRouteName = usePreviousRouteName();
   return (

--- a/versioned_docs/version-7.x/use-navigation-state.md
+++ b/versioned_docs/version-7.x/use-navigation-state.md
@@ -4,6 +4,9 @@ title: useNavigationState
 sidebar_label: useNavigationState
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 `useNavigationState` is a hook which gives access to the [navigation state](navigation-state.md) of the navigator which contains the screen. It's useful in rare cases where you want to render something based on the navigation state.
 
 :::warning
@@ -15,13 +18,13 @@ Consider the navigator's state object to be internal and subject to change in a 
 It takes a selector function as an argument. The selector will receive the full [navigation state](navigation-state.md) and can return a specific value from the state:
 
 ```js
-const index = useNavigationState(state => state.index);
+const index = useNavigationState((state) => state.index);
 ```
 
 The selector function helps to reduce unnecessary re-renders, so your screen will re-render only when that's something you care about. If you actually need the whole state object, you can do this explicitly:
 
 ```js
-const state = useNavigationState(state => state);
+const state = useNavigationState((state) => state);
 ```
 
 :::warning
@@ -44,15 +47,198 @@ function Profile() {
 
 In this example, even if you push a new screen, this text won't update. If you use the hook, it'll work as expected:
 
-<samp id="use-navigation-state" />
+<Tabs groupId="config" queryString="config">
+<TabItem value="static" label="Static" default>
 
-```js
-function Profile() {
-  const routesLength = useNavigationState(state => state.routes.length);
+```js name="useNavigation hook" snack version=7 dependencies=@react-navigation/elements
+import * as React from 'react';
+import Button from '@react-navigation/elements';
+import { View, Text } from 'react-native';
+import {
+  createStaticNavigation,
+  useNavigation,
+  useRoute,
+  useNavigationState,
+} from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
-  return <Text>Number of routes: {routesLength}</Text>;
+// codeblock-focus-start
+function useIsFirstRouteInParent() {
+  const route = useRoute();
+  const isFirstRouteInParent = useNavigationState(
+    (state) => state.routes[0].key === route.key
+  );
+
+  return isFirstRouteInParent;
+}
+
+function usePreviousRouteName() {
+  return useNavigationState((state) =>
+    state.routes[state.index - 1]?.name
+      ? state.routes[state.index - 1].name
+      : 'None'
+  );
+}
+// codeblock-focus-end
+
+function HomeScreen() {
+  const navigation = useNavigation();
+  const isFirstRoute = useIsFirstRouteInParent();
+  const previousRouteName = usePreviousRouteName();
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>It is {isFirstRoute ? '' : 'not '}first route in navigator</Text>
+      <Text>Previous route name: {previousRouteName}</Text>
+
+      <Button onPress={() => navigation.navigate('Profile')}>
+        Go to Profile
+      </Button>
+    </View>
+  );
+}
+
+function ProfileScreen() {
+  const navigation = useNavigation();
+  const isFirstRoute = useIsFirstRouteInParent();
+  const previousRouteName = usePreviousRouteName();
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>It is {isFirstRoute ? '' : 'not '}first route in navigator</Text>
+      <Text>Previous route name: {previousRouteName}</Text>
+      <Button onPress={() => navigation.navigate('Settings')}>
+        Go to Settings
+      </Button>
+      <Button onPress={() => navigation.goBack()}>Go back</Button>
+    </View>
+  );
+}
+
+function SettingsScreen() {
+  const navigation = useNavigation();
+  const isFirstRoute = useIsFirstRouteInParent();
+  const previousRouteName = usePreviousRouteName();
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>It is {isFirstRoute ? '' : 'not '}first route in navigator</Text>
+      <Text>Previous route name: {previousRouteName}</Text>
+      <Button onPress={() => navigation.goBack()}>Go back</Button>
+    </View>
+  );
+}
+
+const Stack = createNativeStackNavigator({
+  screens: {
+    Home: HomeScreen,
+    Profile: ProfileScreen,
+    Settings: SettingsScreen,
+  },
+});
+
+const Navigation = createStaticNavigation(Stack);
+
+export default function App() {
+  return <Navigation />;
 }
 ```
+
+</TabItem>
+<TabItem value="dynamic" label="Dynamic" default>
+
+```js name="useNavigationState hook" snack version=7 dependencies=@react-navigation/elements
+import * as React from 'react';
+import Button from '@react-navigation/elements';
+import { View, Text } from 'react-native';
+import {
+  NavigationContainer,
+  useRoute,
+  useNavigationState,
+} from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+// codeblock-focus-start
+function useIsFirstRouteInParent() {
+  const route = useRoute();
+  const isFirstRouteInParent = useNavigationState(
+    (state) => state.routes[0].key === route.key
+  );
+
+  return isFirstRouteInParent;
+}
+
+function usePreviousRouteName() {
+  return useNavigationState((state) =>
+    state.routes[state.index - 1]?.name
+      ? state.routes[state.index - 1].name
+      : 'None'
+  );
+}
+// codeblock-focus-end
+
+function HomeScreen({ navigation }) {
+  const isFirstRoute = useIsFirstRouteInParent();
+  const previousRouteName = usePreviousRouteName();
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>It is {isFirstRoute ? '' : 'not '}first route in navigator</Text>
+      <Text>Previous route name: {previousRouteName}</Text>
+
+      <Button onPress={() => navigation.navigate('Profile')}>
+        Go to Profile
+      </Button>
+    </View>
+  );
+}
+
+function ProfileScreen({ navigation }) {
+  const isFirstRoute = useIsFirstRouteInParent();
+  const previousRouteName = usePreviousRouteName();
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>It is {isFirstRoute ? '' : 'not '}first route in navigator</Text>
+      <Text>Previous route name: {previousRouteName}</Text>
+      <Button onPress={() => navigation.navigate('Settings')}>
+        Go to Settings
+      </Button>
+      <Button onPress={() => navigation.goBack()}>Go back</Button>
+    </View>
+  );
+}
+
+function SettingsScreen({ navigation }) {
+  const isFirstRoute = useIsFirstRouteInParent();
+  const previousRouteName = usePreviousRouteName();
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>It is {isFirstRoute ? '' : 'not '}first route in navigator</Text>
+      <Text>Previous route name: {previousRouteName}</Text>
+      <Button onPress={() => navigation.goBack()}>Go back</Button>
+    </View>
+  );
+}
+
+const Stack = createNativeStackNavigator();
+
+function MyStack() {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen name="Home" component={HomeScreen} />
+      <Stack.Screen name="Profile" component={ProfileScreen} />
+      <Stack.Screen name="Settings" component={SettingsScreen} />
+    </Stack.Navigator>
+  );
+}
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <MyStack />
+    </NavigationContainer>
+  );
+}
+```
+
+</TabItem>
+</Tabs>
 
 So when do you use `navigation.getState()`? It's mostly useful within event listeners where you don't care about what's rendered. In most cases, using the hook should be preferred.
 
@@ -69,8 +255,8 @@ class Profile extends React.Component {
 }
 
 // Wrap and export
-export default function(props) {
-  const routesLength = useNavigationState(state => state.routes.length);
+export default function (props) {
+  const routesLength = useNavigationState((state) => state.routes.length);
 
   return <Profile {...props} routesLength={routesLength} />;
 }

--- a/versioned_docs/version-7.x/use-navigation-state.md
+++ b/versioned_docs/version-7.x/use-navigation-state.md
@@ -50,7 +50,7 @@ In this example, even if you push a new screen, this text won't update. If you u
 <Tabs groupId="config" queryString="config">
 <TabItem value="static" label="Static" default>
 
-```js name="useNavigation hook" snack version=7 dependencies=@react-navigation/elements
+```js name="useNavigation hook" snack version=7
 import * as React from 'react';
 import Button from '@react-navigation/elements';
 import { View, Text } from 'react-native';
@@ -144,7 +144,7 @@ export default function App() {
 </TabItem>
 <TabItem value="dynamic" label="Dynamic" default>
 
-```js name="useNavigationState hook" snack version=7 dependencies=@react-navigation/elements
+```js name="useNavigationState hook" snack version=7
 import * as React from 'react';
 import Button from '@react-navigation/elements';
 import { View, Text } from 'react-native';

--- a/versioned_docs/version-7.x/use-navigation-state.md
+++ b/versioned_docs/version-7.x/use-navigation-state.md
@@ -58,11 +58,11 @@ import {
   createStaticNavigation,
   useNavigation,
   useRoute,
-  useNavigationState,
 } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-
 // codeblock-focus-start
+import { useNavigationState } from '@react-navigation/native';
+
 function useIsFirstRouteInParent() {
   const route = useRoute();
   const isFirstRouteInParent = useNavigationState(
@@ -152,11 +152,12 @@ import {
   NavigationContainer,
   useRoute,
   useNavigation,
-  useNavigationState,
 } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 // codeblock-focus-start
+import { useNavigationState } from '@react-navigation/native';
+
 function useIsFirstRouteInParent() {
   const route = useRoute();
   const isFirstRouteInParent = useNavigationState(
@@ -175,8 +176,7 @@ function usePreviousRouteName() {
 }
 // codeblock-focus-end
 
-function HomeScreen() {
-  const navigation = useNavigation();
+function HomeScreen({ navigation }) {
   const isFirstRoute = useIsFirstRouteInParent();
   const previousRouteName = usePreviousRouteName();
   return (
@@ -191,8 +191,7 @@ function HomeScreen() {
   );
 }
 
-function ProfileScreen() {
-  const navigation = useNavigation();
+function ProfileScreen({ navigation }) {
   const isFirstRoute = useIsFirstRouteInParent();
   const previousRouteName = usePreviousRouteName();
   return (
@@ -207,8 +206,7 @@ function ProfileScreen() {
   );
 }
 
-function SettingsScreen() {
-  const navigation = useNavigation();
+function SettingsScreen({ navigation }) {
   const isFirstRoute = useIsFirstRouteInParent();
   const previousRouteName = usePreviousRouteName();
   return (

--- a/versioned_docs/version-7.x/use-navigation.md
+++ b/versioned_docs/version-7.x/use-navigation.md
@@ -4,30 +4,144 @@ title: useNavigation
 sidebar_label: useNavigation
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 `useNavigation` is a hook that gives access to `navigation` object. It's useful when you cannot pass the `navigation` object as a prop to the component directly, or don't want to pass it in case of a deeply nested child.
 
 The `useNavigation` hook returns the `navigation` object of the screen where it's used:
 
-<samp id="use-navigation-example" />
+<Tabs groupId="config" queryString="config">
+<TabItem value="static" label="Static" default>
 
-```js
+```js name="useNavigation hook" snack version=7 dependencies=@react-navigation/elements
 import * as React from 'react';
-import { Button } from 'react-native';
+import { View, Text } from 'react-native';
+import { Button } from '@react-navigation/elements';
+import { createStaticNavigation } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+// codeblock-focus-start
 import { useNavigation } from '@react-navigation/native';
 
 function MyBackButton() {
+  // highlight-next-line
   const navigation = useNavigation();
 
   return (
     <Button
-      title="Back"
       onPress={() => {
         navigation.goBack();
       }}
-    />
+    >
+      Back
+    </Button>
   );
 }
+// codeblock-focus-end
+
+function HomeScreen() {
+  const navigation = useNavigation();
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>This is the home screen of the app</Text>
+      <Button onPress={() => navigation.navigate('Profile')}>
+        Go to Profile
+      </Button>
+    </View>
+  );
+}
+
+function ProfileScreen() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Profile Screen</Text>
+      <MyBackButton />
+    </View>
+  );
+}
+
+const Stack = createNativeStackNavigator({
+  initialRouteName: 'Home',
+  screens: {
+    Home: HomeScreen,
+    Profile: ProfileScreen,
+  },
+});
+
+const Navigation = createStaticNavigation(Stack);
+
+function App() {
+  return <Navigation />;
+}
+
+export default App;
 ```
+
+</TabItem>
+<TabItem value="dynamic" label="Dynamic" default>
+
+```js name="useNavigation hook" snack version=7 dependencies=@react-navigation/elements
+import * as React from 'react';
+import { View, Text } from 'react-native';
+import { Button } from '@react-navigation/elements';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+// codeblock-focus-start
+import { useNavigation } from '@react-navigation/native';
+
+function MyBackButton() {
+  // highlight-next-line
+  const navigation = useNavigation();
+
+  return (
+    <Button
+      onPress={() => {
+        navigation.goBack();
+      }}
+    >
+      Back
+    </Button>
+  );
+}
+// codeblock-focus-end
+
+function HomeScreen({ navigation: { navigate } }) {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>This is the home screen of the app</Text>
+      <Button onPress={() => navigate('Profile')}>Go to Profile</Button>
+    </View>
+  );
+}
+
+function ProfileScreen() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Profile Screen</Text>
+      <MyBackButton />
+    </View>
+  );
+}
+
+const Stack = createNativeStackNavigator();
+
+function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName="Home">
+        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="Profile" component={ProfileScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+export default App;
+```
+
+</TabItem>
+</Tabs>
 
 See the documentation for the [`navigation` object](navigation-object.md) for more info.
 
@@ -44,7 +158,7 @@ class MyBackButton extends React.Component {
 }
 
 // Wrap and export
-export default function(props) {
+export default function (props) {
   const navigation = useNavigation();
 
   return <MyBackButton {...props} navigation={navigation} />;

--- a/versioned_docs/version-7.x/use-navigation.md
+++ b/versioned_docs/version-7.x/use-navigation.md
@@ -14,7 +14,7 @@ The `useNavigation` hook returns the `navigation` object of the screen where it'
 <Tabs groupId="config" queryString="config">
 <TabItem value="static" label="Static" default>
 
-```js name="useNavigation hook" snack version=7 dependencies=@react-navigation/elements
+```js name="useNavigation hook" snack version=7
 import * as React from 'react';
 import { View, Text } from 'react-native';
 import { Button } from '@react-navigation/elements';
@@ -81,7 +81,7 @@ export default App;
 </TabItem>
 <TabItem value="dynamic" label="Dynamic" default>
 
-```js name="useNavigation hook" snack version=7 dependencies=@react-navigation/elements
+```js name="useNavigation hook" snack version=7
 import * as React from 'react';
 import { View, Text } from 'react-native';
 import { Button } from '@react-navigation/elements';

--- a/versioned_docs/version-7.x/use-navigation.md
+++ b/versioned_docs/version-7.x/use-navigation.md
@@ -79,7 +79,7 @@ export default App;
 ```
 
 </TabItem>
-<TabItem value="dynamic" label="Dynamic" default>
+<TabItem value="dynamic" label="Dynamic">
 
 ```js name="useNavigation hook" snack version=7
 import * as React from 'react';

--- a/versioned_docs/version-7.x/use-route.md
+++ b/versioned_docs/version-7.x/use-route.md
@@ -80,7 +80,7 @@ export default App;
 ```
 
 </TabItem>
-<TabItem value="dynamic" label="Dynamic" default>
+<TabItem value="dynamic" label="Dynamic">
 
 ```js name="useRoute hook" snack version=7
 import * as React from 'react';

--- a/versioned_docs/version-7.x/use-route.md
+++ b/versioned_docs/version-7.x/use-route.md
@@ -16,7 +16,7 @@ import TabItem from '@theme/TabItem';
 <Tabs groupId="config" queryString="config">
 <TabItem value="static" label="Static" default>
 
-```js name="useRoute hook" snack version=7 dependencies=@react-navigation/elements
+```js name="useRoute hook" snack version=7
 import * as React from 'react';
 import { Button } from '@react-navigation/elements';
 import { View, Text } from 'react-native';
@@ -82,11 +82,11 @@ export default App;
 </TabItem>
 <TabItem value="dynamic" label="Dynamic" default>
 
-```js name="useRoute hook" snack version=7 dependencies=@react-navigation/elements
+```js name="useRoute hook" snack version=7
 import * as React from 'react';
 import { Button } from '@react-navigation/elements';
 import { View, Text } from 'react-native';
-import { NavigationContainer } from '@react-navigation/native';
+import { NavigationContainer, useNavigation } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 // codeblock-focus-start
 import { useRoute } from '@react-navigation/native';
@@ -99,7 +99,9 @@ function MyText() {
 }
 // codeblock-focus-end
 
-function HomeScreen({ navigation: { navigate } }) {
+function HomeScreen() {
+  const navigation = useNavigation();
+
   return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
       <Text>This is the home screen of the app</Text>

--- a/versioned_docs/version-7.x/use-route.md
+++ b/versioned_docs/version-7.x/use-route.md
@@ -4,25 +4,139 @@ title: useRoute
 sidebar_label: useRoute
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 `useRoute` is a hook which gives access to `route` object. It's useful when you cannot pass down the `route` object from props to the component, or don't want to pass it in case of a deeply nested child.
 
 `useRoute()` returns the `route` object of the screen it's inside.
 
 ## Example
 
-<samp id="use-route-example" />
+<Tabs groupId="config" queryString="config">
+<TabItem value="static" label="Static" default>
 
-```js
+```js name="useRoute hook" snack version=7 dependencies=@react-navigation/elements
 import * as React from 'react';
-import { Text } from 'react-native';
+import { Button } from '@react-navigation/elements';
+import { View, Text } from 'react-native';
+import {
+  createStaticNavigation,
+  useNavigation,
+} from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+// codeblock-focus-start
 import { useRoute } from '@react-navigation/native';
 
 function MyText() {
+  // highlight-next-line
   const route = useRoute();
 
   return <Text>{route.params.caption}</Text>;
 }
+// codeblock-focus-end
+
+function HomeScreen() {
+  const navigation = useNavigation();
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>This is the home screen of the app</Text>
+      <Button
+        onPress={() =>
+          navigation.navigate('Profile', { caption: 'Some caption' })
+        }
+      >
+        Go to Profile
+      </Button>
+    </View>
+  );
+}
+
+function ProfileScreen() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Profile Screen</Text>
+      <MyText />
+    </View>
+  );
+}
+
+const Stack = createNativeStackNavigator({
+  initialRouteName: 'Home',
+  screens: {
+    Home: HomeScreen,
+    Profile: ProfileScreen,
+  },
+});
+
+const Navigation = createStaticNavigation(Stack);
+
+function App() {
+  return <Navigation />;
+}
+
+export default App;
 ```
+
+</TabItem>
+<TabItem value="dynamic" label="Dynamic" default>
+
+```js name="useRoute hook" snack version=7 dependencies=@react-navigation/elements
+import * as React from 'react';
+import { Button } from '@react-navigation/elements';
+import { View, Text } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+// codeblock-focus-start
+import { useRoute } from '@react-navigation/native';
+
+function MyText() {
+  // highlight-next-line
+  const route = useRoute();
+
+  return <Text>{route.params.caption}</Text>;
+}
+// codeblock-focus-end
+
+function HomeScreen({ navigation: { navigate } }) {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>This is the home screen of the app</Text>
+      <Button onPress={() => navigate('Profile', { caption: 'Some caption' })}>
+        Go to Profile
+      </Button>
+    </View>
+  );
+}
+
+function ProfileScreen() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Profile Screen</Text>
+      <MyText />
+    </View>
+  );
+}
+
+const Stack = createNativeStackNavigator();
+
+function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName="Home">
+        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="Profile" component={ProfileScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+export default App;
+```
+
+</TabItem>
+</Tabs>
 
 See the documentation for the [`route` object](route-object.md) for more info.
 
@@ -39,7 +153,7 @@ class MyText extends React.Component {
 }
 
 // Wrap and export
-export default function(props) {
+export default function (props) {
   const route = useRoute();
 
   return <MyText {...props} route={route} />;

--- a/versioned_docs/version-7.x/use-route.md
+++ b/versioned_docs/version-7.x/use-route.md
@@ -84,8 +84,8 @@ export default App;
 
 ```js name="useRoute hook" snack version=7
 import * as React from 'react';
-import { Button } from '@react-navigation/elements';
 import { View, Text } from 'react-native';
+import { Button } from '@react-navigation/elements';
 import { NavigationContainer, useNavigation } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 // codeblock-focus-start

--- a/versioned_docs/version-7.x/use-route.md
+++ b/versioned_docs/version-7.x/use-route.md
@@ -18,8 +18,8 @@ import TabItem from '@theme/TabItem';
 
 ```js name="useRoute hook" snack version=7
 import * as React from 'react';
-import { Button } from '@react-navigation/elements';
 import { View, Text } from 'react-native';
+import { Button } from '@react-navigation/elements';
 import {
   createStaticNavigation,
   useNavigation,
@@ -43,9 +43,9 @@ function HomeScreen() {
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
       <Text>This is the home screen of the app</Text>
       <Button
-        onPress={() =>
-          navigation.navigate('Profile', { caption: 'Some caption' })
-        }
+        onPress={() => {
+          navigation.navigate('Profile', { caption: 'Some caption' });
+        }}
       >
         Go to Profile
       </Button>
@@ -99,13 +99,15 @@ function MyText() {
 }
 // codeblock-focus-end
 
-function HomeScreen() {
-  const navigation = useNavigation();
-
+function HomeScreen({ navigation }) {
   return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
       <Text>This is the home screen of the app</Text>
-      <Button onPress={() => navigate('Profile', { caption: 'Some caption' })}>
+      <Button
+        onPress={() => {
+          navigation.navigate('Profile', { caption: 'Some caption' });
+        }}
+      >
         Go to Profile
       </Button>
     </View>

--- a/versioned_docs/version-7.x/use-scroll-to-top.md
+++ b/versioned_docs/version-7.x/use-scroll-to-top.md
@@ -19,12 +19,11 @@ Example:
 ```js name="useScrollToTop hook" snack version=7
 import * as React from 'react';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { createStaticNavigation } from '@react-navigation/native';
+import { View, Image } from 'react-native';
 // codeblock-focus-start
-import { View, ScrollView, Image } from 'react-native';
-import {
-  createStaticNavigation,
-  useScrollToTop,
-} from '@react-navigation/native';
+import { ScrollView } from 'react-native';
+import { useScrollToTop } from '@react-navigation/native';
 
 function Albums() {
   const ref = React.useRef(null);
@@ -34,7 +33,7 @@ function Albums() {
 
   return (
     <ScrollView ref={ref}>
-      {/*content*/}
+      {/* content */}
       // codeblock-focus-end
       <Image
         source={{ uri: 'https://facebook.github.io/react/logo-og.png' }}
@@ -84,9 +83,11 @@ export default function App() {
 ```js name="useScrollToTop hook" snack version=7
 import * as React from 'react';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { View, Image } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
 // codeblock-focus-start
-import { View, ScrollView, Image } from 'react-native';
-import { NavigationContainer, useScrollToTop } from '@react-navigation/native';
+import { ScrollView } from 'react-native';
+import { useScrollToTop } from '@react-navigation/native';
 
 function Albums() {
   const ref = React.useRef(null);
@@ -176,12 +177,12 @@ If you require offset to scroll position you can wrap and decorate passed refere
 ```js name="useScrollToTop hook - providing scroll offset" snack version=7
 import * as React from 'react';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { View, Image } from 'react-native';
+import { createStaticNavigation } from '@react-navigation/native';
+
 // codeblock-focus-start
-import { View, ScrollView, Image } from 'react-native';
-import {
-  createStaticNavigation,
-  useScrollToTop,
-} from '@react-navigation/native';
+import { ScrollView } from 'react-native';
+import { useScrollToTop } from '@react-navigation/native';
 
 function Albums() {
   const ref = React.useRef(null);
@@ -246,9 +247,11 @@ export default function App() {
 ```js name="useScrollToTop hook - providing scroll offset" snack version=7
 import * as React from 'react';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { View, Image } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
 // codeblock-focus-start
-import { View, ScrollView, Image } from 'react-native';
-import { NavigationContainer, useScrollToTop } from '@react-navigation/native';
+import { ScrollView } from 'react-native';
+import { useScrollToTop } from '@react-navigation/native';
 
 function Albums() {
   const ref = React.useRef(null);

--- a/versioned_docs/version-7.x/use-scroll-to-top.md
+++ b/versioned_docs/version-7.x/use-scroll-to-top.md
@@ -4,27 +4,146 @@ title: useScrollToTop
 sidebar_label: useScrollToTop
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 The expected native behavior of scrollable components is to respond to events from navigation that will scroll to top when tapping on the active tab as you would expect from native tab bars.
 
 In order to achieve it we export `useScrollToTop` which accept ref to scrollable component (e,g. `ScrollView` or `FlatList`).
 
 Example:
 
-<samp id="use-scroll-to-top" />
+<Tabs groupId="config" queryString="config">
+<TabItem value="static" label="Static" default>
 
-```js
+```js name="useScrollToTop hook" snack version=7
 import * as React from 'react';
-import { ScrollView } from 'react-native';
-import { useScrollToTop } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+// codeblock-focus-start
+import { View, ScrollView, Image } from 'react-native';
+import {
+  createStaticNavigation,
+  useScrollToTop,
+} from '@react-navigation/native';
 
 function Albums() {
   const ref = React.useRef(null);
 
+  // highlight-next-line
   useScrollToTop(ref);
 
-  return <ScrollView ref={ref}>{/* content */}</ScrollView>;
+  return (
+    <ScrollView ref={ref}>
+      {/*content*/}
+      // codeblock-focus-end
+      <Image
+        source={{ uri: 'https://facebook.github.io/react/logo-og.png' }}
+        style={{ width: 400, height: 400 }}
+        key="1"
+      />
+      <Image
+        source={{ uri: 'https://facebook.github.io/react/logo-og.png' }}
+        style={{ width: 400, height: 400 }}
+        key="2"
+      />
+      <Image
+        source={{ uri: 'https://facebook.github.io/react/logo-og.png' }}
+        style={{ width: 400, height: 400 }}
+        key="3"
+      />
+      <Image
+        source={{ uri: 'https://facebook.github.io/react/logo-og.png' }}
+        style={{ width: 400, height: 400 }}
+        key="4"
+      />
+      // codeblock-focus-start
+    </ScrollView>
+  );
+}
+// codeblock-focus-end
+
+function HomeScreen() {
+  return <View />;
+}
+
+const Tab = createBottomTabNavigator({
+  Home: HomeScreen,
+  Albums: Albums,
+});
+
+const Navigation = createStaticNavigation(Tab);
+
+export default function App() {
+  return <Navigation />;
 }
 ```
+
+</TabItem>
+<TabItem value="dynamic" label="Dynamic" default>
+
+```js name="useScrollToTop hook" snack version=7
+import * as React from 'react';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+// codeblock-focus-start
+import { View, ScrollView, Image } from 'react-native';
+import { NavigationContainer, useScrollToTop } from '@react-navigation/native';
+
+function Albums() {
+  const ref = React.useRef(null);
+
+  // highlight-next-line
+  useScrollToTop(ref);
+
+  return (
+    <ScrollView ref={ref}>
+      {/* content */}
+      // codeblock-focus-end
+      <Image
+        source={{ uri: 'https://facebook.github.io/react/logo-og.png' }}
+        style={{ width: 400, height: 400 }}
+        key="1"
+      />
+      <Image
+        source={{ uri: 'https://facebook.github.io/react/logo-og.png' }}
+        style={{ width: 400, height: 400 }}
+        key="2"
+      />
+      <Image
+        source={{ uri: 'https://facebook.github.io/react/logo-og.png' }}
+        style={{ width: 400, height: 400 }}
+        key="3"
+      />
+      <Image
+        source={{ uri: 'https://facebook.github.io/react/logo-og.png' }}
+        style={{ width: 400, height: 400 }}
+        key="4"
+      />
+      // codeblock-focus-start
+    </ScrollView>
+  );
+}
+// codeblock-focus-end
+
+function HomeScreen() {
+  return <View />;
+}
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Tab.Navigator>
+        <Tab.Screen name="Home" component={HomeScreen} />
+        <Tab.Screen name="Albums" component={Albums} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}
+```
+
+</TabItem>
+</Tabs>
 
 ## Using with class component
 
@@ -51,12 +170,18 @@ export default function (props) {
 
 If you require offset to scroll position you can wrap and decorate passed reference:
 
-<samp id="use-scroll-to-top-offset" />
+<Tabs groupId="config" queryString="config">
+<TabItem value="static" label="Static" default>
 
-```js
+```js name="useScrollToTop hook - providing scroll offset" snack version=7
 import * as React from 'react';
-import { ScrollView } from 'react-native';
-import { useScrollToTop } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+// codeblock-focus-start
+import { View, ScrollView, Image } from 'react-native';
+import {
+  createStaticNavigation,
+  useScrollToTop,
+} from '@react-navigation/native';
 
 function Albums() {
   const ref = React.useRef(null);
@@ -67,6 +192,120 @@ function Albums() {
     })
   );
 
-  return <ScrollView ref={ref}>{/* content */}</ScrollView>;
+  return (
+    <ScrollView ref={ref}>
+      {/* content */}
+      // codeblock-focus-end
+      <Image
+        source={{ uri: 'https://facebook.github.io/react/logo-og.png' }}
+        style={{ width: 400, height: 400 }}
+        key="1"
+      />
+      <Image
+        source={{ uri: 'https://facebook.github.io/react/logo-og.png' }}
+        style={{ width: 400, height: 400 }}
+        key="2"
+      />
+      <Image
+        source={{ uri: 'https://facebook.github.io/react/logo-og.png' }}
+        style={{ width: 400, height: 400 }}
+        key="3"
+      />
+      <Image
+        source={{ uri: 'https://facebook.github.io/react/logo-og.png' }}
+        style={{ width: 400, height: 400 }}
+        key="4"
+      />
+      // codeblock-focus-start
+    </ScrollView>
+  );
+}
+// codeblock-focus-end
+
+function HomeScreen() {
+  return <View />;
+}
+
+const Tab = createBottomTabNavigator({
+  screens: {
+    Home: HomeScreen,
+    Albums: Albums,
+  },
+});
+
+const Navigation = createStaticNavigation(Tab);
+
+export default function App() {
+  return <Navigation />;
 }
 ```
+
+</TabItem>
+<TabItem value="dynamic" label="Dynamic" default>
+
+```js name="useScrollToTop hook - providing scroll offset" snack version=7
+import * as React from 'react';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+// codeblock-focus-start
+import { View, ScrollView, Image } from 'react-native';
+import { NavigationContainer, useScrollToTop } from '@react-navigation/native';
+
+function Albums() {
+  const ref = React.useRef(null);
+
+  useScrollToTop(
+    React.useRef({
+      scrollToTop: () => ref.current?.scrollTo({ y: 100 }),
+    })
+  );
+
+  return (
+    <ScrollView ref={ref}>
+      {/* content */}
+      // codeblock-focus-end
+      <Image
+        source={{ uri: 'https://facebook.github.io/react/logo-og.png' }}
+        style={{ width: 400, height: 400 }}
+        key="1"
+      />
+      <Image
+        source={{ uri: 'https://facebook.github.io/react/logo-og.png' }}
+        style={{ width: 400, height: 400 }}
+        key="2"
+      />
+      <Image
+        source={{ uri: 'https://facebook.github.io/react/logo-og.png' }}
+        style={{ width: 400, height: 400 }}
+        key="3"
+      />
+      <Image
+        source={{ uri: 'https://facebook.github.io/react/logo-og.png' }}
+        style={{ width: 400, height: 400 }}
+        key="4"
+      />
+      // codeblock-focus-start
+    </ScrollView>
+  );
+}
+// codeblock-focus-end
+
+function HomeScreen() {
+  return <View />;
+}
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Tab.Navigator>
+        <Tab.Screen name="Home" component={HomeScreen} />
+        <Tab.Screen name="Albums" component={Albums} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}
+```
+
+</TabItem>
+</Tabs>

--- a/versioned_docs/version-7.x/use-scroll-to-top.md
+++ b/versioned_docs/version-7.x/use-scroll-to-top.md
@@ -79,7 +79,7 @@ export default function App() {
 ```
 
 </TabItem>
-<TabItem value="dynamic" label="Dynamic" default>
+<TabItem value="dynamic" label="Dynamic">
 
 ```js name="useScrollToTop hook" snack version=7
 import * as React from 'react';
@@ -241,7 +241,7 @@ export default function App() {
 ```
 
 </TabItem>
-<TabItem value="dynamic" label="Dynamic" default>
+<TabItem value="dynamic" label="Dynamic">
 
 ```js name="useScrollToTop hook - providing scroll offset" snack version=7
 import * as React from 'react';

--- a/versioned_docs/version-7.x/use-theme.md
+++ b/versioned_docs/version-7.x/use-theme.md
@@ -4,16 +4,58 @@ title: useTheme
 sidebar_label: useTheme
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 The `useTheme` hook lets us access the currently active theme. You can use it in your own components to have them respond to changes in the theme.
 
-<samp id="system-themes" />
+<Tabs groupId="config" queryString="config">
+<TabItem value="static" label="Static" default>
 
-```js
+```js name="useTheme hook" snack version=7 dependencies=@react-navigation/elements
 import * as React from 'react';
-import { TouchableOpacity, Text } from 'react-native';
-import { useTheme } from '@react-navigation/native';
+// codeblock-focus-start
+import {
+  useNavigation,
+  createStaticNavigation,
+  DefaultTheme,
+  DarkTheme,
+  useTheme,
+} from '@react-navigation/native';
+import { Button, View, Text, TouchableOpacity, Appearance } from 'react-native';
+// codeblock-focus-end
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { createDrawerNavigator } from '@react-navigation/drawer';
 
-// Black background and white text in light theme, inverted on dark theme
+function SettingsScreen({ route }) {
+  const navigation = useNavigation();
+  const { user } = route.params;
+  const { colors } = useTheme();
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text style={{ color: colors.text }}>Settings Screen</Text>
+      <Text style={{ color: colors.text }}>
+        userParam: {JSON.stringify(user)}
+      </Text>
+      <Button
+        title="Go to Profile"
+        onPress={() => navigation.navigate('Profile')}
+      />
+    </View>
+  );
+}
+
+function ProfileScreen() {
+  const { colors } = useTheme();
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text style={{ color: colors.text }}>Profile Screen</Text>
+    </View>
+  );
+}
+
 function MyButton() {
   const { colors } = useTheme();
 
@@ -23,7 +65,175 @@ function MyButton() {
     </TouchableOpacity>
   );
 }
+
+function HomeScreen() {
+  const navigation = useNavigation();
+  const { colors } = useTheme();
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text style={{ color: colors.text }}>Home Screen</Text>
+      <MyButton />
+      <Button
+        title="Go to Settings"
+        onPress={() =>
+          navigation.navigate('Root', {
+            screen: 'Settings',
+            params: { user: 'jane' },
+          })
+        }
+      />
+    </View>
+  );
+}
+
+const PanelStack = createNativeStackNavigator({
+  screens: {
+    Profile: ProfileScreen,
+    Settings: SettingsScreen,
+  },
+});
+
+const Drawer = createDrawerNavigator({
+  initialRouteName: 'Panel',
+  screens: {
+    Home: HomeScreen,
+    Panel: {
+      screen: PanelStack,
+      options: {
+        headerShown: false,
+      },
+    },
+  },
+});
+
+// codeblock-focus-start
+
+const Navigation = createStaticNavigation(Drawer);
+
+export default function App() {
+  // highlight-next-line
+  const scheme = Appearance.getColorScheme();
+
+  // highlight-next-line
+  return <Navigation theme={scheme === 'dark' ? DarkTheme : DefaultTheme} />;
+}
+
+// codeblock-focus-end
 ```
+
+</TabItem>
+<TabItem value="dynamic" label="Dynamic" default>
+
+```js name="useTheme hook" snack version=7 dependencies=@react-navigation/elements
+import * as React from 'react';
+// codeblock-focus-start
+import { Button, View, Text, TouchableOpacity, Appearance } from 'react-native';
+import {
+  NavigationContainer,
+  DefaultTheme,
+  DarkTheme,
+  useTheme,
+} from '@react-navigation/native';
+// codeblock-focus-end
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { createDrawerNavigator } from '@react-navigation/drawer';
+
+function SettingsScreen({ route, navigation }) {
+  const { user } = route.params;
+  const { colors } = useTheme();
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text style={{ color: colors.text }}>Settings Screen</Text>
+      <Text style={{ color: colors.text }}>
+        userParam: {JSON.stringify(user)}
+      </Text>
+      <Button
+        title="Go to Profile"
+        onPress={() => navigation.navigate('Profile')}
+      />
+    </View>
+  );
+}
+
+function ProfileScreen() {
+  const { colors } = useTheme();
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text style={{ color: colors.text }}>Profile Screen</Text>
+    </View>
+  );
+}
+
+function MyButton() {
+  const { colors } = useTheme();
+
+  return (
+    <TouchableOpacity style={{ backgroundColor: colors.card }}>
+      <Text style={{ color: colors.text }}>Button!</Text>
+    </TouchableOpacity>
+  );
+}
+
+function HomeScreen({ navigation }) {
+  const { colors } = useTheme();
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text style={{ color: colors.text }}>Home Screen</Text>
+      <MyButton />
+      <Button
+        title="Go to Settings"
+        onPress={() =>
+          navigation.navigate('Root', {
+            screen: 'Settings',
+            params: { user: 'jane' },
+          })
+        }
+      />
+    </View>
+  );
+}
+
+const Drawer = createDrawerNavigator();
+const Stack = createNativeStackNavigator();
+
+function Root() {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen name="Profile" component={ProfileScreen} />
+      <Stack.Screen name="Settings" component={SettingsScreen} />
+    </Stack.Navigator>
+  );
+}
+
+// codeblock-focus-start
+
+export default function App() {
+  // highlight-next-line
+  const scheme = Appearance.getColorScheme();
+
+  return (
+    // highlight-next-line
+    <NavigationContainer theme={scheme === 'dark' ? DarkTheme : DefaultTheme}>
+      <Drawer.Navigator useLegacyImplementation>
+        <Drawer.Screen name="Home" component={HomeScreen} />
+        <Drawer.Screen
+          name="Root"
+          component={Root}
+          options={{ headerShown: false }}
+        />
+      </Drawer.Navigator>
+    </NavigationContainer>
+  );
+}
+// codeblock-focus-end
+```
+
+</TabItem>
+</Tabs>
 
 See [theming guide](themes.md) for more details and usage guide around how to configure themes.
 
@@ -40,7 +250,7 @@ class MyButton extends React.Component {
 }
 
 // Wrap and export
-export default function(props) {
+export default function (props) {
   const theme = useTheme();
 
   return <MyButton {...props} theme={theme} />;

--- a/versioned_docs/version-7.x/use-theme.md
+++ b/versioned_docs/version-7.x/use-theme.md
@@ -12,7 +12,7 @@ The `useTheme` hook lets us access the currently active theme. You can use it in
 <Tabs groupId="config" queryString="config">
 <TabItem value="static" label="Static" default>
 
-```js name="useTheme hook" snack version=7 dependencies=@react-navigation/elements
+```js name="useTheme hook" snack version=7
 import * as React from 'react';
 // codeblock-focus-start
 import {
@@ -125,7 +125,7 @@ export default function App() {
 </TabItem>
 <TabItem value="dynamic" label="Dynamic" default>
 
-```js name="useTheme hook" snack version=7 dependencies=@react-navigation/elements
+```js name="useTheme hook" snack version=7
 import * as React from 'react';
 // codeblock-focus-start
 import { Button, View, Text, TouchableOpacity, Appearance } from 'react-native';

--- a/versioned_docs/version-7.x/use-theme.md
+++ b/versioned_docs/version-7.x/use-theme.md
@@ -14,18 +14,19 @@ The `useTheme` hook lets us access the currently active theme. You can use it in
 
 ```js name="useTheme hook" snack version=7
 import * as React from 'react';
-// codeblock-focus-start
 import {
   useNavigation,
   createStaticNavigation,
   DefaultTheme,
   DarkTheme,
-  useTheme,
 } from '@react-navigation/native';
 import { Button, View, Text, TouchableOpacity, Appearance } from 'react-native';
-// codeblock-focus-end
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { createDrawerNavigator } from '@react-navigation/drawer';
+
+// codeblock-focus-start
+import { useTheme } from '@react-navigation/native';
+// codeblock-focus-end
 
 function SettingsScreen({ route }) {
   const navigation = useNavigation();
@@ -46,7 +47,9 @@ function SettingsScreen({ route }) {
   );
 }
 
+// codeblock-focus-start
 function ProfileScreen() {
+  // highlight-next-line
   const { colors } = useTheme();
 
   return (
@@ -55,6 +58,7 @@ function ProfileScreen() {
     </View>
   );
 }
+// codeblock-focus-end
 
 function MyButton() {
   const { colors } = useTheme();
@@ -107,19 +111,12 @@ const Drawer = createDrawerNavigator({
   },
 });
 
-// codeblock-focus-start
-
 const Navigation = createStaticNavigation(Drawer);
 
 export default function App() {
-  // highlight-next-line
   const scheme = Appearance.getColorScheme();
-
-  // highlight-next-line
   return <Navigation theme={scheme === 'dark' ? DarkTheme : DefaultTheme} />;
 }
-
-// codeblock-focus-end
 ```
 
 </TabItem>
@@ -127,18 +124,19 @@ export default function App() {
 
 ```js name="useTheme hook" snack version=7
 import * as React from 'react';
-// codeblock-focus-start
 import { Button, View, Text, TouchableOpacity, Appearance } from 'react-native';
 import {
   NavigationContainer,
   DefaultTheme,
   DarkTheme,
-  useTheme,
   useNavigation,
 } from '@react-navigation/native';
-// codeblock-focus-end
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { createDrawerNavigator } from '@react-navigation/drawer';
+
+// codeblock-focus-start
+import { useTheme } from '@react-navigation/native';
+// codeblock-focus-end
 
 function SettingsScreen({ route }) {
   const navigation = useNavigation();
@@ -158,8 +156,9 @@ function SettingsScreen({ route }) {
     </View>
   );
 }
-
+// codeblock-focus-start
 function ProfileScreen() {
+  // highlight-next-line
   const { colors } = useTheme();
 
   return (
@@ -168,6 +167,7 @@ function ProfileScreen() {
     </View>
   );
 }
+// codeblock-focus-end
 
 function MyButton() {
   const { colors } = useTheme();
@@ -212,14 +212,10 @@ function Root() {
   );
 }
 
-// codeblock-focus-start
-
 export default function App() {
-  // highlight-next-line
   const scheme = Appearance.getColorScheme();
 
   return (
-    // highlight-next-line
     <NavigationContainer theme={scheme === 'dark' ? DarkTheme : DefaultTheme}>
       <Drawer.Navigator useLegacyImplementation>
         <Drawer.Screen name="Home" component={HomeScreen} />
@@ -232,7 +228,6 @@ export default function App() {
     </NavigationContainer>
   );
 }
-// codeblock-focus-end
 ```
 
 </TabItem>

--- a/versioned_docs/version-7.x/use-theme.md
+++ b/versioned_docs/version-7.x/use-theme.md
@@ -134,12 +134,14 @@ import {
   DefaultTheme,
   DarkTheme,
   useTheme,
+  useNavigation,
 } from '@react-navigation/native';
 // codeblock-focus-end
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { createDrawerNavigator } from '@react-navigation/drawer';
 
-function SettingsScreen({ route, navigation }) {
+function SettingsScreen({ route }) {
+  const navigation = useNavigation();
   const { user } = route.params;
   const { colors } = useTheme();
 
@@ -177,7 +179,8 @@ function MyButton() {
   );
 }
 
-function HomeScreen({ navigation }) {
+function HomeScreen() {
+  const navigation = useNavigation();
   const { colors } = useTheme();
 
   return (

--- a/versioned_docs/version-7.x/use-theme.md
+++ b/versioned_docs/version-7.x/use-theme.md
@@ -26,6 +26,7 @@ import { createDrawerNavigator } from '@react-navigation/drawer';
 
 // codeblock-focus-start
 import { useTheme } from '@react-navigation/native';
+
 // codeblock-focus-end
 
 function SettingsScreen({ route }) {
@@ -47,9 +48,7 @@ function SettingsScreen({ route }) {
   );
 }
 
-// codeblock-focus-start
 function ProfileScreen() {
-  // highlight-next-line
   const { colors } = useTheme();
 
   return (
@@ -58,9 +57,10 @@ function ProfileScreen() {
     </View>
   );
 }
-// codeblock-focus-end
 
+// codeblock-focus-start
 function MyButton() {
+  // highlight-next-line
   const { colors } = useTheme();
 
   return (
@@ -69,6 +69,7 @@ function MyButton() {
     </TouchableOpacity>
   );
 }
+// codeblock-focus-end
 
 function HomeScreen() {
   const navigation = useNavigation();
@@ -136,8 +137,8 @@ import { createDrawerNavigator } from '@react-navigation/drawer';
 
 // codeblock-focus-start
 import { useTheme } from '@react-navigation/native';
-// codeblock-focus-end
 
+// codeblock-focus-end
 function SettingsScreen({ route }) {
   const navigation = useNavigation();
   const { user } = route.params;
@@ -156,9 +157,7 @@ function SettingsScreen({ route }) {
     </View>
   );
 }
-// codeblock-focus-start
 function ProfileScreen() {
-  // highlight-next-line
   const { colors } = useTheme();
 
   return (
@@ -167,9 +166,10 @@ function ProfileScreen() {
     </View>
   );
 }
-// codeblock-focus-end
 
+// codeblock-focus-start
 function MyButton() {
+  // highlight-next-line
   const { colors } = useTheme();
 
   return (
@@ -178,6 +178,7 @@ function MyButton() {
     </TouchableOpacity>
   );
 }
+// codeblock-focus-end
 
 function HomeScreen() {
   const navigation = useNavigation();

--- a/versioned_docs/version-7.x/use-theme.md
+++ b/versioned_docs/version-7.x/use-theme.md
@@ -123,7 +123,7 @@ export default function App() {
 ```
 
 </TabItem>
-<TabItem value="dynamic" label="Dynamic" default>
+<TabItem value="dynamic" label="Dynamic">
 
 ```js name="useTheme hook" snack version=7
 import * as React from 'react';


### PR DESCRIPTION
Add static examples to hooks from `Hooks` section of `API reference`.

- [useNavigation](https://reactnavigation.org/docs/7.x/use-navigation) - done
- [useRoute](https://reactnavigation.org/docs/7.x/use-route) - done
- [useNavigationState](https://reactnavigation.org/docs/7.x/use-navigation-state) - done
- [useFocusEffect](https://reactnavigation.org/docs/7.x/use-focus-effect) - done
- [useIsFocused](https://reactnavigation.org/docs/7.x/use-is-focused) - done
- [useLinkTo](https://reactnavigation.org/docs/7.x/use-link-to) - nothing to add
- [useLinkProps](https://reactnavigation.org/docs/7.x/use-link-props) - nothing to add
- [useLinkBuilder](https://reactnavigation.org/docs/7.x/use-link-builder) - nothing to add
- [useScrollToTop](https://reactnavigation.org/docs/7.x/use-scroll-to-top) - done
- [useTheme](https://reactnavigation.org/docs/7.x/use-theme) - done