### PR TITLE
Fix screen-options.md typo

### DIFF
--- a/versioned_docs/version-6.x/screen-options.md
+++ b/versioned_docs/version-6.x/screen-options.md
@@ -89,7 +89,7 @@ Similar to `options`, you can also pass a function to `screenOptions`. The funct
 
 ### `screenOptions` prop on the navigator
 
-You can pass a prop named `screenOptions` to the navigator component, where you can specify an object with different options. The options specified in `screenOptions` apply to all of the screens in the navigator. So this is a good place to add specify options that you want to configure for the whole navigator.
+You can pass a prop named `screenOptions` to the navigator component, where you can specify an object with different options. The options specified in `screenOptions` apply to all of the screens in the navigator. So this is a good place to specify options that you want to configure for the whole navigator.
 
 Example:
 

--- a/versioned_docs/version-7.x/screen-options.md
+++ b/versioned_docs/version-7.x/screen-options.md
@@ -357,7 +357,7 @@ const Stack = createNativeStackNavigator({
 
 ### `screenOptions` prop on the navigator
 
-You can pass a prop named `screenOptions` to the navigator component, where you can specify an object with different options. The options specified in `screenOptions` apply to all of the screens in the navigator. So this is a good place to add specify options that you want to configure for the whole navigator.
+You can pass a prop named `screenOptions` to the navigator component, where you can specify an object with different options. The options specified in `screenOptions` apply to all of the screens in the navigator. So this is a good place to specify options that you want to configure for the whole navigator.
 
 Example:
 


### PR DESCRIPTION
this fixes a possible typo: `to add specify` → `to specify`

I only found this typo in `version-6.x` and `version-7.x` so I updated it only there