### PR TITLE
Fix typo/grammar in screen-options docs

### DIFF
--- a/versioned_docs/version-6.x/screen-options.md
+++ b/versioned_docs/version-6.x/screen-options.md
@@ -89,7 +89,7 @@ Similar to `options`, you can also pass a function to `screenOptions`. The funct
 
 ### `screenOptions` prop on the navigator
 
-You can pass a prop named `screenOptions` to the navigator component, where you can specify an object with different options. The options specified in `screenOptions` apply to all of the screens in the navigator. So this is a good place to add specify options that you want to configure for the whole navigator.
+You can pass a prop named `screenOptions` to the navigator component, where you can specify an object with different options. The options specified in `screenOptions` apply to all of the screens in the navigator. So this is a good place to add specific options that you want to configure for the whole navigator.
 
 Example:
 

--- a/versioned_docs/version-7.x/screen-options.md
+++ b/versioned_docs/version-7.x/screen-options.md
@@ -357,7 +357,7 @@ const Stack = createNativeStackNavigator({
 
 ### `screenOptions` prop on the navigator
 
-You can pass a prop named `screenOptions` to the navigator component, where you can specify an object with different options. The options specified in `screenOptions` apply to all of the screens in the navigator. So this is a good place to add specify options that you want to configure for the whole navigator.
+You can pass a prop named `screenOptions` to the navigator component, where you can specify an object with different options. The options specified in `screenOptions` apply to all of the screens in the navigator. So this is a good place to add specific options that you want to configure for the whole navigator.
 
 Example:
 


### PR DESCRIPTION
# READ ME PLEASE

> **TL;DR: Make sure to add your changes to versioned docs**

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
