### PR TITLE
Update typescript.md

### DIFF
--- a/versioned_docs/version-5.x/typescript.md
+++ b/versioned_docs/version-5.x/typescript.md
@@ -252,7 +252,7 @@ import { NavigationContainerRef } from '@react-navigation/native';
 
 // ...
 
-const navigationRef = React.useRef<NavigationContainerRef>(null);
+const navigationRef = React.useRef<NavigationContainerRef<{}>>(null);
 ```
 
 Example when using `React.createRef`:


### PR DESCRIPTION
Without <{}> TypeScript compiler shows this error: Generic type 'NavigationContainerRef' requires 1 type argument(s).ts(2314)

# READ ME PLEASE

> **TL;DR: Make sure to add your changes to versioned docs**

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
