### PR TITLE
feat: respect user's preferred color scheme

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,6 +11,11 @@ export default {
   projectName: 'react-navigation.github.io',
   scripts: ['/js/snack-helpers.js', '/js/toc-fixes.js'],
   themeConfig: {
+    colorMode: {
+      defaultMode: 'light',
+      disableSwitch: false,
+      respectPrefersColorScheme: true,
+    },
     prism: {
       theme: require('prism-react-renderer').themes.github,
       darkTheme: require('prism-react-renderer').themes.dracula,


### PR DESCRIPTION
These are the changes to the [Docusaurus theme config](https://docusaurus.io/docs/api/themes/configuration#color-mode---dark-mode) so that it prefers the user's system color scheme instead of just defaulting to the light one.

I left the light mode as the default for cases when system preferences are unavailable, to be consistent with the official [react.dev](https://react.dev/) documentation ([see this line of code](https://github.com/reactjs/react.dev/blob/main/src/styles/index.css#L384)) and the official React Native documentation (https://github.com/facebook/react-native-website/pull/4262) in this regard.