### PR TITLE
remove tabBarIconStyle from material-top-tab-navigator options

### DIFF
--- a/versioned_docs/version-7.x/material-top-tab-navigator.md
+++ b/versioned_docs/version-7.x/material-top-tab-navigator.md
@@ -398,10 +398,6 @@ Boolean indicating whether to make the tab bar scrollable.
 
 If you set this to `true`, you should also specify a width in `tabBarItemStyle` to improve the performance of initial render.
 
-#### `tabBarIconStyle`
-
-Style object for the tab icon container.
-
 #### `tabBarLabelStyle`
 
 Style object for the tab label.


### PR DESCRIPTION
This option was removed in https://github.com/react-navigation/react-navigation/pull/11548