### PR TITLE
add breaking-change headerTruncatedBackTitle to the doc

### DIFF
--- a/versioned_docs/version-7.x/stack-navigator.md
+++ b/versioned_docs/version-7.x/stack-navigator.md
@@ -435,7 +435,7 @@ Function which returns a React Element to display custom image in header's back 
 
 Title string used by the back button on iOS. Defaults to the previous scene's title. Use `headerBackButtonDisplayMode` to customize the behavior.
 
-#### `headerTruncatedBackTitle`
+#### `headerBackTruncatedTitle`
 
 Title string used by the back button when `headerBackTitle` doesn't fit on the screen. `"Back"` by default.
 

--- a/versioned_docs/version-7.x/upgrading-from-6.x.md
+++ b/versioned_docs/version-7.x/upgrading-from-6.x.md
@@ -258,6 +258,8 @@ The previous behavior can be achieved by setting `headerBackButtonDisplayMode` t
 />
 ```
 
+Similarly, the `headerTruncatedBackTitle` option in Stack Navigator is renamed to `headerBackTruncatedTitle` for consistency.
+
 #### `animationEnabled` option is removed in favor of `animation` option in Stack Navigator
 
 Previously, `animationEnabled: false` was used to disable the animation for the screen transition in Stack Navigator.


### PR DESCRIPTION
The change of `headerTruncatedBackTitle` to `headerBackTruncatedTitle` isn't mentioned in the upgrade helper and the v7 doc isn't updated.

https://github.com/react-navigation/react-navigation/pull/12090