### PR TITLE
Remove mention of jest-native in testing docs

### DIFF
--- a/versioned_docs/version-7.x/testing.md
+++ b/versioned_docs/version-7.x/testing.md
@@ -58,7 +58,7 @@ If you're not using Jest, then you'll need to mock these modules according to th
 
 ## Writing tests
 
-We recommend using [React Native Testing Library](https://callstack.github.io/react-native-testing-library/) along with [`jest-native`](https://github.com/testing-library/jest-native) to write your tests.
+We recommend using [React Native Testing Library](https://callstack.github.io/react-native-testing-library/) to write your tests.
 
 Example:
 


### PR DESCRIPTION
Removed section mentioning `jest-native` package for setting up tests, as it is deprecated and is not used with newer versions of React Native Testing Library.