### PR TITLE
Update shared-element-transitions.md

### DIFF
--- a/versioned_docs/version-7.x/shared-element-transitions.md
+++ b/versioned_docs/version-7.x/shared-element-transitions.md
@@ -7,7 +7,7 @@ sidebar_label: Shared element transitions
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-This guide covers how to animate elements between screens. This feature is known as a [Shared Element Transition](https://docs.swmansion.com/react-native-reanimated/docs/api/sharedElementTransitions) and it's implemented in the [`@react-navigation/native-stack`](native-stack-navigator.md) with [React Native Reanimated](https://docs.swmansion.com/react-native-reanimated/).
+This guide covers how to animate elements between screens. This feature is known as a [Shared Element Transition](https://docs.swmansion.com/react-native-reanimated/docs/shared-element-transitions/overview/) and it's implemented in the [`@react-navigation/native-stack`](native-stack-navigator.md) with [React Native Reanimated](https://docs.swmansion.com/react-native-reanimated/).
 
 :::warning
 
@@ -25,6 +25,7 @@ Before continuing this guide make sure your app meets these criteria:
 
 - You are using [`@react-navigation/native-stack`](native-stack-navigator.md). The Shared Element Transitions feature isn't supported in JS-based [`@react-navigation/stack`](stack-navigator.md).
 - You have [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started) **v3.0.0 or higher** installed and configured.
+- You are using the old React Native architecture. The current implementation does not support the new architecture (Fabric).
 
 ## Minimal example
 


### PR DESCRIPTION
While recently trying to implement shared transitions in my project, I was stumped when I followed all the directions in the docs and it didn't work. Upon further inspection (looking at the reanimated docs) the issue is that Fabric is not currently supported. 

Changes: 

- Fix broken link to reanimated documentation
- Add note about lack of support for new architecture
