### PR TITLE
Fix ternary typo in `bottom-tab-navigator.md`

### DIFF
--- a/versioned_docs/version-7.x/bottom-tab-navigator.md
+++ b/versioned_docs/version-7.x/bottom-tab-navigator.md
@@ -495,7 +495,7 @@ When the tab bar is positioned on the `left` or `right`, it is styled as a sideb
 ```js
 const Tabs = createBottomTabNavigator({
   screenOptions: {
-    tabBarPosition: isLargeScreen ? 'left' ? 'bottom',
+    tabBarPosition: isLargeScreen ? 'left' : 'bottom',
   },
 
   // ...
@@ -508,7 +508,7 @@ const Tabs = createBottomTabNavigator({
 ```js
 <Tab.Navigator
   screenOptions={{
-    tabBarPosition: isLargeScreen ? 'left' ? 'bottom',
+    tabBarPosition: isLargeScreen ? 'left' : 'bottom',
   }}
 >
 ```
@@ -526,7 +526,7 @@ You can also render a compact sidebar by placing the label below the icon. This 
 ```js
 const Tabs = createBottomTabNavigator({
   screenOptions: {
-    tabBarPosition: isLargeScreen ? 'left' ? 'bottom',
+    tabBarPosition: isLargeScreen ? 'left' : 'bottom',
     tabBarVariant: isLargeScreen ? 'material' : 'uikit',
     tabBarLabelPosition: 'below-icon',
   },


### PR DESCRIPTION
Typo fixes for ternary operators I found while working with the example code. 

Also checked historical versions of the page but didn't find any problems there. 