### PR TITLE
Update react-native-screens.md for enableScreens import

### DIFF
--- a/versioned_docs/version-2.x/react-native-screens.md
+++ b/versioned_docs/version-2.x/react-native-screens.md
@@ -14,8 +14,8 @@ By default expo already included `react-native-screens`, all you need to do is p
 
 ```js
 // Before rendering any navigation stack
-import { useScreens } from 'react-native-screens';
-useScreens();
+import { enableScreens } from 'react-native-screens';
+enableScreens();
 ```
 
 ## Setup in normal react-native applications


### PR DESCRIPTION
`enableScreens` is being used instead of `useScreens`

# READ ME PLEASE

> **TL;DR: Make sure to add your changes to versioned docs**

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
