### PR TITLE
Fix typo in auth-flow.md

### DIFF
--- a/versioned_docs/version-7.x/auth-flow.md
+++ b/versioned_docs/version-7.x/auth-flow.md
@@ -278,7 +278,7 @@ In the above snippet, `isLoading` means that we're still checking if we have a t
 
 Next, we're exposing the sign in status via the `SignInContext` so that it's available to the `useIsSignedIn` and `useIsSignedOut` hooks.
 
-In the above example, we're have one screen for each case. But you could also define multiple screens. For example, you probably want to define password reset, signup, etc screens as well when the user isn't signed in. Similarly for the screens accessible after sign in, you probably have more than one screen. We can use [`groups`](static-configuration.md#groups) to define multiple screens:
+In the above example, we have one screen for each case. But you could also define multiple screens. For example, you probably want to define password reset, signup, etc screens as well when the user isn't signed in. Similarly for the screens accessible after sign in, you probably have more than one screen. We can use [`groups`](static-configuration.md#groups) to define multiple screens:
 
 ```js
 const RootStack = createNativeStackNavigator({


### PR DESCRIPTION
# Change
I changed "...we're have..." which is the contraction form of "...we are have...". The proposed change is "...we have...", however, please feel free to suggest a different fix.

# Question
I read the text generated when I started the PR. I *think* I edited the file it was meaning (i.e. the versioned docs file). Please let me know if I misunderstood and I am happy to correct my error.