### PR TITLE
Fix `:::warning` syntax in server-rendering docs

### DIFF
--- a/versioned_docs/version-7.x/server-rendering.md
+++ b/versioned_docs/version-7.x/server-rendering.md
@@ -12,7 +12,7 @@ This guide will cover how to server render your React Native app using React Nat
 1. Rendering the correct layout depending on the request URL
 2. Setting appropriate page metadata based on the focused screen
 
-::: warning
+:::warning
 
 Server rendering support is currently limited. It's not possible to provide a seamless SSR experience due to a lack of APIs such as media queries. In addition, many third-party libraries often don't work well with server rendering.
 


### PR DESCRIPTION
Removed extra space in `:::warning` syntax in `versioned_docs/version-7.x/server-rendering.md` to enable proper rendering as a highlighted markdown warning block.

[Before](https://reactnavigation.org/docs/server-rendering)|[After](https://deploy-preview-1423--react-navigation-docs.netlify.app/docs/server-rendering)
-|-
<img width="250" alt="before" src="https://github.com/user-attachments/assets/46e313cf-f3d1-4bc8-bee8-a17c8f63f99d" />|<img width="250" alt="after" src="https://github.com/user-attachments/assets/37ede2aa-def3-471c-83f2-934b5372edb6" />

