### PR TITLE
Fix typo in server-rendering pages

### DIFF
--- a/versioned_docs/version-5.x/server-rendering.md
+++ b/versioned_docs/version-5.x/server-rendering.md
@@ -163,7 +163,7 @@ function NotFound() {
   const status = React.useContext(StatusCodeContext);
 
   if (status) {
-    staus.code = 404;
+    status.code = 404;
   }
 
   return (

--- a/versioned_docs/version-6.x/server-rendering.md
+++ b/versioned_docs/version-6.x/server-rendering.md
@@ -161,7 +161,7 @@ function NotFound() {
   const status = React.useContext(StatusCodeContext);
 
   if (status) {
-    staus.code = 404;
+    status.code = 404;
   }
 
   return (

--- a/versioned_docs/version-7.x/server-rendering.md
+++ b/versioned_docs/version-7.x/server-rendering.md
@@ -213,7 +213,7 @@ function NotFound() {
   const status = React.useContext(StatusCodeContext);
 
   if (status) {
-    staus.code = 404;
+    status.code = 404;
   }
 
   return (


### PR DESCRIPTION
Just fixing a typo from `staus` to `status`