### PR TITLE
Add information about nested stack and headerShown being unsupported for formSheet on Android

### DIFF
--- a/versioned_docs/version-7.x/native-stack-navigator.md
+++ b/versioned_docs/version-7.x/native-stack-navigator.md
@@ -1071,6 +1071,9 @@ On iOS, `flex: 1` with `showAllowedDetents: 'fitToContents'` works properly but 
 If you don't use `flex: 1` but the content's height is less than max screen height, the rest of the sheet might become translucent or use the default theme background color (you can see this happening on the screenshots in the descrption of [this PR](https://github.com/software-mansion/react-native-screens/pull/2462)). To match the sheet to the background of your content, set `backgroundColor` in the `contentStyle` prop of the given screen.
 
 On Android, there are also some problems with getting nested ScrollViews to work properly. The solution is to set `nestedScrollEnabled` on the `ScrollView`, but this does not work if the content's height is less than the `ScrollView`'s height. Please see [this PR](https://github.com/facebook/react-native/pull/44099) for details and suggested [workaround](https://github.com/facebook/react-native/pull/44099#issuecomment-2058469661).
+
+On Android, nested stack and `headerShown` prop are not currently supported for screens with `presentation: 'formSheet'`.
+
 :::
 
 #### `sheetAllowedDetents`


### PR DESCRIPTION
## Description

Add information about `headerShown` prop and nested stack in a `presentation: 'formSheet'` screens being currently unsupported on Android.

Thanks to @ljukas for [pointing out](https://github.com/software-mansion/react-native-screens/issues/2657#issuecomment-2862131079) the missing docs.