### PR TITLE
Add Swift AppDelegate setup instructions for deep linking

### DIFF
--- a/versioned_docs/version-7.x/deep-linking.md
+++ b/versioned_docs/version-7.x/deep-linking.md
@@ -72,10 +72,7 @@ function App() {
 
   return (
     <NavigationContainer linking={linking} fallback={<Text>Loading...</Text>}>
-      {/* content */}
-    </NavigationContainer>
-  );
-}
+      {/* content */
 ```
 
 </TabItem>
@@ -124,6 +121,28 @@ If your app is using [Universal Links](https://developer.apple.com/ios/universal
  return [RCTLinkingManager application:application
                   continueUserActivity:userActivity
                     restorationHandler:restorationHandler];
+}
+```
+
+If you're using Swift, you'll need to add the following to your `AppDelegate.swift` file. You can find more information in the [React Native documentation](https://reactnative.dev/docs/linking?ios-language=swift).
+
+```swift
+// Add this to your AppDelegate.swift file
+
+import React
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+        return RCTLinkingManager.application(application, open: url, options: options)
+    }
+
+    // For Universal Links
+    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+        return RCTLinkingManager.application(application, continue: userActivity, restorationHandler: restorationHandler)
+    }
 }
 ```
 


### PR DESCRIPTION
This PR adds an alternative setup option for iOS projects using Swift, introduced in React Native v0.79.0. The new section provides developers with the necessary AppDelegate.swift implementation for handling deep links.

It includes new Swift code snippets for configuring deep linking in the AppDelegate.swift file, enhancing the documentation for users implementing Universal Links in their React Native applications. The previous content has been slightly modified for clarity.