### PR TITLE
chore(github): comment out notational pieces of PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!--
+
 # READ ME PLEASE
 
 > **TL;DR: Make sure to add your changes to versioned docs**
@@ -7,3 +9,5 @@ Thanks for opening a PR!
 The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").
 
 Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:
+
+-->


### PR DESCRIPTION
## Summary

Use an HTML comment for notational pieces of the PR template

## Details

- very similar to an old PR of mine in a different repo: https://github.com/argoproj/argo-helm/pull/1969
- the notes about versioned docs are purely notational, i.e. have nothing to fill out
  - comment them out with HTML comments, as is common practice
    - example from a repo I maintain: https://github.com/ezolenko/rollup-plugin-typescript2/blob/f6db59613a66f58c48310aa8fa785951970b5d6d/.github/issue_template.md?plain=1#L2
      - I copied that from other repos too
  - these comments are still visible to the PR author, just not visible when rendered, keeping the PR more concise

Can see an example of what this looks like below vvv. If a maintainer clicks the edit button, will be able to see that the note is still there, just commented out and invisible when rendered.

<!-- 

# READ ME PLEASE

> **TL;DR: Make sure to add your changes to versioned docs**

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:

-->