### PR TITLE
docs: add missing status bar docs

### DIFF
--- a/versioned_docs/version-6.x/native-stack-navigator.md
+++ b/versioned_docs/version-6.x/native-stack-navigator.md
@@ -457,14 +457,16 @@ Only supported on Android and iOS.
 
 #### `statusBarStyle`
 
-Sets the status bar color (similar to the `StatusBar` component). Defaults to `auto`.
+Sets the status bar color (similar to the `StatusBar` component).
 
 Supported values:
 
-- `"auto"`
+- `"auto"` (iOS only)
 - `"inverted"` (iOS only)
 - `"dark"`
 - `"light"`
+
+Defaults to `auto` on iOS and `light` on Android.
 
 Requires setting `View controller-based status bar appearance -> YES` (or removing the config) in your `Info.plist` file.
 

--- a/versioned_docs/version-7.x/native-stack-navigator.md
+++ b/versioned_docs/version-7.x/native-stack-navigator.md
@@ -711,14 +711,16 @@ Only supported on Android and iOS.
 
 #### `statusBarStyle`
 
-Sets the status bar color (similar to the `StatusBar` component). Defaults to `auto`.
+Sets the status bar color (similar to the `StatusBar` component).
 
 Supported values:
 
-- `"auto"`
+- `"auto"` (iOS only)
 - `"inverted"` (iOS only)
 - `"dark"`
 - `"light"`
+
+Defaults to `auto` on iOS and `light` on Android.
 
 Requires setting `View controller-based status bar appearance -> YES` (or removing the config) in your `Info.plist` file.
 


### PR DESCRIPTION
**Motivation**

Recently noticed that docs for `statusBarStyle` and `statusBarHidden` are not kept in sync between files in `react-native-screens` repo, `react-naviagtion` in-code docs and `reactnavigation.org/docs`.

I added information about `auto` and `inverted` values not being supported on Android for `statusBarStyle`.

Similar PR in `react-native-screens`: https://github.com/software-mansion/react-native-screens/pull/2953, `react-navigation`: https://github.com/react-navigation/react-navigation/pull/12618.
