### PR TITLE
Fix typo in community libraries: React Native Header Motion

### DIFF
--- a/versioned_docs/version-7.x/community-libraries.md
+++ b/versioned_docs/version-7.x/community-libraries.md
@@ -30,7 +30,7 @@ Provides simple HOCs that map react-navigation props to your screen components d
 
 [Repository](https://github.com/vonovak/react-navigation-props-mapper)
 
-## react-navigation-header-motion
+## react-native-header-motion
 
 Provides building blocks for scroll-driven animated headers in React Native. It can be used with React Navigation to create collapsible, progress-driven headers, including headers rendered by the navigator itself via bridging components.
 

--- a/versioned_docs/version-8.x/community-libraries.md
+++ b/versioned_docs/version-8.x/community-libraries.md
@@ -30,7 +30,7 @@ Provides simple HOCs that map react-navigation props to your screen components d
 
 [Repository](https://github.com/vonovak/react-navigation-props-mapper)
 
-## react-navigation-header-motion
+## react-native-header-motion
 
 Provides building blocks for scroll-driven animated headers in React Native. It can be used with React Navigation to create collapsible, progress-driven headers, including headers rendered by the navigator itself via bridging components.
 


### PR DESCRIPTION
<!--

# READ ME PLEASE

> **TL;DR: Make sure to add your changes to versioned docs**

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:

-->

Hey @satya164, me again!

So I don't know how I did that but I made a typo in the name of my own library [when adding it here to the docs](https://github.com/react-navigation/react-navigation.github.io/pull/1484), in the Community Libraries section. This PR here fixes it

Thanks and sorry!
