### PR TITLE
docs: add `overrideScrollViewContentInsetAdjustmentBehavior` option to bottom tab navigator

### DIFF
--- a/versioned_docs/version-7.x/native-bottom-tab-navigator.md
+++ b/versioned_docs/version-7.x/native-bottom-tab-navigator.md
@@ -503,6 +503,26 @@ When `false`, tapping on the tab in tab bar won't select the tab. Custom behavio
 
 Defaults to `true`.
 
+#### `overrideScrollViewContentInsetAdjustmentBehavior`
+
+Whether to override the `contentInsetAdjustmentBehavior` of the first `ScrollView` in the first descendant chain from the tab screen.
+
+By default, React Native's `ScrollView` has `contentInsetAdjustmentBehavior` set to `never` instead of the UIKit default (`automatic`), which prevents `ScrollView`s from respecting navigation bar insets. When this option is `true`, that override is applied, restoring UIKit's `automatic` behavior for the first descendant `ScrollView`.
+
+Defaults to `true`. To disable for specific screens — for example to fix a blank gap appearing above content in a nested native-stack screen that uses `headerTransparent: true` — set the option to `false`:
+
+```js
+<Tab.Screen
+  name="Journal"
+  component={JournalStackNavigator}
+  options={{
+    overrideScrollViewContentInsetAdjustmentBehavior: false,
+  }}
+/>
+```
+
+Only supported on iOS.
+
 #### `bottomAccessory`
 
 Function that returns a React element to display as an accessory view. The function receives an options object with a `placement` parameter that can be one of the following values:

--- a/versioned_docs/version-8.x/bottom-tab-navigator.md
+++ b/versioned_docs/version-8.x/bottom-tab-navigator.md
@@ -1043,6 +1043,26 @@ When `false`, tapping on the tab in tab bar won't select the tab. Custom behavio
 
 Defaults to `true`.
 
+#### `overrideScrollViewContentInsetAdjustmentBehavior`
+
+Whether to override the `contentInsetAdjustmentBehavior` of the first `ScrollView` in the first descendant chain from the tab screen.
+
+By default, React Native's `ScrollView` has `contentInsetAdjustmentBehavior` set to `never` instead of the UIKit default (`automatic`), which prevents `ScrollView`s from respecting navigation bar insets. When this option is `true`, that override is applied, restoring UIKit's `automatic` behavior for the first descendant `ScrollView`.
+
+Defaults to `true`. To disable for specific screens — for example to fix a blank gap appearing above content in a nested native-stack screen that uses `headerTransparent: true` — set the option to `false`:
+
+```js
+<Tab.Screen
+  name="Journal"
+  component={JournalStackNavigator}
+  options={{
+    overrideScrollViewContentInsetAdjustmentBehavior: false,
+  }}
+/>
+```
+
+Only supported on iOS.
+
 #### `bottomAccessory`
 
 Function that returns a React element to display as an accessory view. The function receives an options object with a `placement` parameter that can be one of the following values:


### PR DESCRIPTION
Closes #1491.

## Summary

The `overrideScrollViewContentInsetAdjustmentBehavior` option has been exposed on `Tab.Screen` via `@react-navigation/bottom-tabs/unstable` types ([source](https://github.com/react-navigation/react-navigation/blob/main/packages/bottom-tabs/src/unstable/types.tsx#L358)) since `react-native-screens` started exposing it natively. It's iOS-only, defaults to `true`, and currently has no entry on the public docs site — only the JSDoc in the TypeScript source.

It's the only escape hatch for a fairly common visible symptom on iOS:

> A blank gap appears above the content of a native-stack screen with `headerTransparent: true` when that screen lives inside a `NativeTabs` tab. Setting `<ScrollView contentInsetAdjustmentBehavior="never" />` doesn't reliably fix it because rn-screens deliberately overrides this back to `automatic` for the first descendant `ScrollView` of each tab.

Reported with the same symptom in [react-navigation/react-navigation#12946](https://github.com/react-navigation/react-navigation/issues/12946); the option was added in response but never landed in the docs.

## Changes

Added a new option section between `tabBarSelectionEnabled` and `bottomAccessory` in:

- `versioned_docs/version-7.x/native-bottom-tab-navigator.md`
- `versioned_docs/version-8.x/bottom-tab-navigator.md`

The wording mirrors the existing JSDoc and includes a minimal code example showing how to disable the override on a specific tab.

## Test plan

- [x] Renders cleanly in the Markdown preview
- [x] Diff is additive only — no existing content modified
- [ ] Reviewer to confirm placement / wording matches style of surrounding options