### PR TITLE
docs: add native bottom tabs inset adjustment option

### DIFF
--- a/versioned_docs/version-7.x/native-bottom-tab-navigator.md
+++ b/versioned_docs/version-7.x/native-bottom-tab-navigator.md
@@ -477,6 +477,18 @@ The display mode for the tab bar. Supported values:
 
 Only supported on iOS 18 and above. Not supported on tvOS.
 
+#### `overrideScrollViewContentInsetAdjustmentBehavior`
+
+Whether to override the `contentInsetAdjustmentBehavior` of the first `ScrollView` in the first descendant chain from the tab screen.
+
+By default, React Native's `ScrollView` has `contentInsetAdjustmentBehavior` set to `never` instead of UIKit's default `automatic`. Setting this option to `true` restores the automatic behavior so scroll views respect navigation bar insets.
+
+Set this option to `false` to disable this behavior for specific screens.
+
+Defaults to `true`.
+
+Only supported on iOS.
+
 #### `tabBarMinimizeBehavior`
 
 The minimize behavior for the tab bar. Supported values:


### PR DESCRIPTION
## Summary

- documents the `overrideScrollViewContentInsetAdjustmentBehavior` option for native bottom tabs
- adds it alongside the other native bottom tab options so users can discover the inset adjustment behavior

Closes #1491.

## Test plan

- `git diff --check`