### PR TITLE
docs: remove mention of deprecated \jest-native\ (Fixes #1335)

### DIFF
--- a/versioned_docs/version-6.x/testing.md
+++ b/versioned_docs/version-6.x/testing.md
@@ -55,7 +55,7 @@ If you're not using Jest, then you'll need to mock these modules according to th
 
 ## Writing tests
 
-We recommend using [React Native Testing Library](https://callstack.github.io/react-native-testing-library/) along with [`jest-native`](https://github.com/testing-library/jest-native) to write your tests.
+We recommend using [React Native Testing Library](https://callstack.github.io/react-native-testing-library/) to write your tests.
 
 Example:
 


### PR DESCRIPTION
This PR resolves #1335 by removing references to the deprecated \jest-native\ package from the version 6.x and 7.x testing documentation.