### PR TITLE
Note that screenLayout is called as a function, not a component

### DIFF
--- a/versioned_docs/version-7.x/group.md
+++ b/versioned_docs/version-7.x/group.md
@@ -287,6 +287,26 @@ const MyStack = createNativeStackNavigator({
 </TabItem>
 </ConfigTabs>
 
+:::warning
+
+The function passed to `screenLayout` is invoked as a regular function, not rendered as a React component. This means you **cannot call React Hooks directly inside it** — doing so will fail at runtime with errors such as _"Should have a queue. You are likely calling Hooks conditionally, which is not allowed."_
+
+If you need to use Hooks, wrap your logic in a separate component and return it as JSX:
+
+```jsx
+function MyScreenLayout(props) {
+  const value = useMyHook(); // ✅ Hook runs inside a real component
+
+  return <ErrorBoundary>{props.children}</ErrorBoundary>;
+}
+
+const Stack = createNativeStackNavigator({
+  screenLayout: (props) => <MyScreenLayout {...props} />,
+});
+```
+
+:::
+
 ### Navigation key
 
 Optional key for a group of screens. If the key changes, all existing screens in this group will be removed (if used in a stack navigator) or reset (if used in a tab or drawer navigator):

--- a/versioned_docs/version-7.x/navigator.md
+++ b/versioned_docs/version-7.x/navigator.md
@@ -310,6 +310,26 @@ function MyStack() {
 </TabItem>
 </ConfigTabs>
 
+:::warning
+
+The function passed to `screenLayout` is invoked as a regular function, not rendered as a React component. This means you **cannot call React Hooks directly inside it** — doing so will fail at runtime with errors such as _"Should have a queue. You are likely calling Hooks conditionally, which is not allowed."_
+
+If you need to use Hooks, wrap your logic in a separate component and return it as JSX:
+
+```jsx
+function MyScreenLayout(props) {
+  const value = useMyHook(); // ✅ Hook runs inside a real component
+
+  return <ErrorBoundary>{props.children}</ErrorBoundary>;
+}
+
+const Stack = createNativeStackNavigator({
+  screenLayout: (props) => <MyScreenLayout {...props} />,
+});
+```
+
+:::
+
 ### Router
 
 :::warning

--- a/versioned_docs/version-8.x/group.md
+++ b/versioned_docs/version-8.x/group.md
@@ -287,6 +287,26 @@ const MyStack = createNativeStackNavigator({
 </TabItem>
 </ConfigTabs>
 
+:::warning
+
+The function passed to `screenLayout` is invoked as a regular function, not rendered as a React component. This means you **cannot call React Hooks directly inside it** — doing so will fail at runtime with errors such as _"Should have a queue. You are likely calling Hooks conditionally, which is not allowed."_
+
+If you need to use Hooks, wrap your logic in a separate component and return it as JSX:
+
+```jsx
+function MyScreenLayout(props) {
+  const value = useMyHook(); // ✅ Hook runs inside a real component
+
+  return <ErrorBoundary>{props.children}</ErrorBoundary>;
+}
+
+const Stack = createNativeStackNavigator({
+  screenLayout: (props) => <MyScreenLayout {...props} />,
+});
+```
+
+:::
+
 ### Navigation key
 
 Optional key for a group of screens. If the key changes, all existing screens in this group will be removed (if used in a stack navigator) or reset (if used in a tab or drawer navigator):

--- a/versioned_docs/version-8.x/navigator.md
+++ b/versioned_docs/version-8.x/navigator.md
@@ -270,6 +270,26 @@ function MyStack() {
 </TabItem>
 </ConfigTabs>
 
+:::warning
+
+The function passed to `screenLayout` is invoked as a regular function, not rendered as a React component. This means you **cannot call React Hooks directly inside it** — doing so will fail at runtime with errors such as _"Should have a queue. You are likely calling Hooks conditionally, which is not allowed."_
+
+If you need to use Hooks, wrap your logic in a separate component and return it as JSX:
+
+```jsx
+function MyScreenLayout(props) {
+  const value = useMyHook(); // ✅ Hook runs inside a real component
+
+  return <ErrorBoundary>{props.children}</ErrorBoundary>;
+}
+
+const Stack = createNativeStackNavigator({
+  screenLayout: (props) => <MyScreenLayout {...props} />,
+});
+```
+
+:::
+
 ### Router
 
 Routers can be customized with the `router` prop on navigator to override how navigation actions are handled.


### PR DESCRIPTION
## Problem

The [`screenLayout` documentation](https://reactnavigation.org/docs/navigator#screen-layout) describes it as "a function that returns a React element," and all examples return JSX immediately. This is correct but implicit — a developer who needs to call a hook inside `screenLayout` (e.g., to read theme context, access app state, etc.) discovers only at runtime that React throws:

> Should have a queue. You are likely calling Hooks conditionally, which is not allowed.

The root cause is that React Navigation invokes `screenLayout` via a plain function call ([`useDescriptors.tsx:267-275`](https://github.com/react-navigation/react-navigation/blob/main/packages/core/src/useDescriptors.tsx#L267-L275)), not via JSX. Hooks called inside have no React fiber to register against. The misleading "conditionally" wording in React's error sent me searching for a conditional that didn't exist.

## Solution

Add a warning block (with workaround) after the existing `screenLayout` examples in both `navigator.md` and `group.md` for v7 and v8. The workaround is to wrap hook logic in a real component and return it as JSX — then React mounts it properly and hooks work.

## Why

I hit this myself and lost real time to it. The current examples all return JSX immediately (which sidesteps the issue), so there's no way to anticipate it from reading the docs. The error message points at conditional hook calls, but the actual problem is the function-invocation pattern — which the docs don't currently surface.

## Scope

Same note added to all 4 files where the screenLayout section appears:

- `versioned_docs/version-7.x/navigator.md`
- `versioned_docs/version-7.x/group.md`
- `versioned_docs/version-8.x/navigator.md`
- `versioned_docs/version-8.x/group.md`

Marked as a `:::warning` rather than `:::note` for visual prominence — this is a real footgun, not a footnote. Existing `:::warning` blocks in these files (e.g., the `Router` section about experimental APIs) use the same styling.

Verified `markdownlint-cli2` and `prettier` both pass on the changed files.