### PR TITLE
fix: Change 'title' to 'label' in unstable header items example

### DIFF
--- a/versioned_docs/version-7.x/native-stack-navigator.md
+++ b/versioned_docs/version-7.x/native-stack-navigator.md
@@ -926,7 +926,7 @@ Example:
 unstable_headerLeftItems: () => [
   {
     type: 'button',
-    title: 'Edit',
+    label: 'Edit',
     onPress: () => {
       // Do something
     },
@@ -970,7 +970,7 @@ Example:
 unstable_headerRightItems: () => [
   {
     type: 'button',
-    title: 'Edit',
+    label: 'Edit',
     onPress: () => {
       // Do something
     },


### PR DESCRIPTION
<!--

# READ ME PLEASE

> **TL;DR: Make sure to add your changes to versioned docs**

Thanks for opening a PR!

The docs cover several versions of `react-navigation`, and in some cases there are several files (for version 1, version 2 and etc.) that all describe a single page of the docs (eg. "Getting Started").

Please make sure that the edit you're making in `docs/file-you-edited.md` is also included in the file for the correct version, eg. `/versioned_docs/version-3.x/file-you-edited.md` for version 3. If such file doesn't exist, please create it. :+1:

-->

As [defined in the types](https://github.com/react-navigation/react-navigation/blob/e617cd23944247da3fa5e7b2827d662d6c8b9874/packages/native-stack/src/types.tsx#L852), ist must be `label` instead `title`
